### PR TITLE
dump load contraction orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.vscode/
 /Manifest.toml
+_local/

--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "0.6.3"
 
 [deps]
 BetterExp = "7cffe744-45fd-4178-b173-cf893948b8b7"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 OMEinsum = "ebe7aa44-baf0-506c-a96f-8464559b3922"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 
 [compat]
+JSON = "0.21"
 BetterExp = "0.1"
 OMEinsum = "0.6.5"
 Requires = "1"
@@ -18,10 +20,10 @@ Suppressor = "0.2"
 julia = "1"
 
 [extras]
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 KaHyPar = "2a6221f6-aa48-11e9-3542-2d9e0ef01880"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 
 [targets]
 test = ["Test", "Random", "KaHyPar", "Graphs"]

--- a/src/OMEinsumContractionOrders.jl
+++ b/src/OMEinsumContractionOrders.jl
@@ -5,6 +5,7 @@ using SparseArrays, Suppressor
 using OMEinsum
 using OMEinsum: NestedEinsum, getixsv, getiyv, DynamicEinCode, StaticEinCode, isleaf, MinSpaceDiff, MinSpaceOut
 export MinSpaceDiff, MinSpaceOut
+using JSON
 
 using Requires
 function __init__()
@@ -38,5 +39,6 @@ include("sa.jl")
 include("treesa.jl")
 include("simplify.jl")
 include("interfaces.jl")
+include("json.jl")
 
 end

--- a/src/json.jl
+++ b/src/json.jl
@@ -1,0 +1,71 @@
+using JSON
+
+export dumptofile, loadfromfile
+
+function dumptofile(filename::AbstractString, ne::Union{NestedEinsum, SlicedEinsum})
+    if ne isa NestedEinsum
+        dict = _todict(ne)
+    else
+        dict = _todict(ne.eins)
+        dict["slices"] = ne.slicing.legs
+    end
+    open(filename, "w") do f
+        JSON.print(f, dict, 4)
+    end
+end
+function _todict(ne::NestedEinsum)
+    LT = labeltype(ne)
+    dict = Dict{String,Any}("label-type"=>LT, "inputs"=>getixsv(ne), "output"=>getiyv(ne))
+    dict["tree"] = todict(ne)
+    return dict
+end
+function loadfromfile(filename::AbstractString)
+    dict = JSON.parsefile(filename)
+    lt = dict["label-type"]
+    LT = if lt == "Char"
+        Char
+    elseif lt ∈ ("Int64", "Int", "Int32")
+        Int
+    else
+        error("label type `$lt` not known.")
+    end
+    ne = fromdict(LT, dict["tree"])
+    if haskey(dict, "slices")
+        return SlicedEinsum(Slicing(_convert.(LT, dict["slices"])), ne)
+    else
+        return ne
+    end
+end
+
+function todict(ne::NestedEinsum)
+    dict = Dict{String,Any}()
+    if OMEinsum.isleaf(ne)
+        dict["isleaf"] = true
+        dict["tensorindex"] = ne.tensorindex
+        return dict
+    end
+    dict["args"] = collect(todict.(ne.args))
+    dict["eins"] = einstodict(ne.eins)
+    dict["isleaf"] = false
+    return dict
+end
+function einstodict(eins::EinCode)
+    ixs = getixsv(eins)
+    iy = getiyv(eins)
+    return Dict("ixs"=>ixs, "iy"=>iy)
+end
+
+function fromdict(::Type{LT}, dict::Dict) where LT
+    if dict["isleaf"]
+        return NestedEinsum{DynamicEinCode{LT}}(dict["tensorindex"])
+    end
+    eins = einsfromdict(LT, dict["eins"])
+    return NestedEinsum(fromdict.(LT, dict["args"]), eins)
+end
+
+function einsfromdict(::Type{LT}, dict::Dict) where LT
+    return EinCode([_convert.(LT, ix) for ix in dict["ixs"]], _convert.(LT, dict["iy"]))
+end
+
+_convert(::Type{LT}, x) where LT = convert(LT, x)
+_convert(::Type{Char}, x::String) where LT = (@assert length(x)==1; x[1])

--- a/src/json.jl
+++ b/src/json.jl
@@ -1,8 +1,8 @@
 using JSON
 
-export dumptofile, loadfromfile
+export writejson, readjson
 
-function dumptofile(filename::AbstractString, ne::Union{NestedEinsum, SlicedEinsum})
+function writejson(filename::AbstractString, ne::Union{NestedEinsum, SlicedEinsum})
     if ne isa NestedEinsum
         dict = _todict(ne)
     else
@@ -19,7 +19,7 @@ function _todict(ne::NestedEinsum)
     dict["tree"] = todict(ne)
     return dict
 end
-function loadfromfile(filename::AbstractString)
+function readjson(filename::AbstractString)
     dict = JSON.parsefile(filename)
     lt = dict["label-type"]
     LT = if lt == "Char"
@@ -64,7 +64,7 @@ function fromdict(::Type{LT}, dict::Dict) where LT
 end
 
 function einsfromdict(::Type{LT}, dict::Dict) where LT
-    return EinCode([_convert.(LT, ix) for ix in dict["ixs"]], _convert.(LT, dict["iy"]))
+    return EinCode([collect(LT, _convert.(LT, ix)) for ix in dict["ixs"]], collect(LT, _convert.(LT, dict["iy"])))
 end
 
 _convert(::Type{LT}, x) where LT = convert(LT, x)

--- a/test/json.jl
+++ b/test/json.jl
@@ -8,8 +8,8 @@ using Test, OMEinsumContractionOrders, OMEinsum
         for optcode in [optimize_code(code, uniformsize(code, 2), GreedyMethod()),
             optimize_code(code, uniformsize(code, 2), TreeSA(nslices=1))]
             filename = tempname()
-            dumptofile(filename, optcode)
-            code2 = loadfromfile(filename)
+            writejson(filename, optcode)
+            code2 = readjson(filename)
             @test optcode == code2
         end
     end

--- a/test/json.jl
+++ b/test/json.jl
@@ -1,0 +1,16 @@
+using Test, OMEinsumContractionOrders, OMEinsum
+
+@testset "save load" begin
+    for code in [
+        EinCode([[1,2], [2,3], [3,4]], [1,4]),
+        EinCode([['a','b'], ['b','c'], ['c','d']], ['a','d'])
+    ]
+        for optcode in [optimize_code(code, uniformsize(code, 2), GreedyMethod()),
+            optimize_code(code, uniformsize(code, 2), TreeSA(nslices=1))]
+            filename = tempname()
+            dumptofile(filename, optcode)
+            code2 = loadfromfile(filename)
+            @test optcode == code2
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,3 +24,7 @@ end
 @testset "interfaces" begin
     include("interfaces.jl")
 end
+
+@testset "json" begin
+    include("json.jl")
+end


### PR DESCRIPTION
```julia
julia> using OMEinsum, OMEinsumContractionOrders, Graphs

julia> optcode_tree = optimize_code(code, uniformsize(code, 2), TreeSA(sc_target=28, βs=0.1:0.1:10,
                                                                ntrials=2, niters=100, sc_weight=3.0, nslices=4));

julia> timespace_complexity(optcode_tree, uniformsize(code, 2))
(29.762953599372096, 21.0)

julia> writejson("test.json", optcode_tree)

julia> optcode_loaded = readjson("test.json")
SlicedEinsum{Int64, NestedEinsum{DynamicEinCode{Int64}}}(Slicing{Int64}([110, 106, 54, 189]), 12, 12 -> 
├─ 64∘12, 12∘64 -> 12
│  ├─ 11∘12, 12∘64∘11 -> 12∘64
│  │  ├─ 51∘136∘12, 51∘64∘11∘136 -> 12∘64∘11
│  │  │  ├─ 64∘134∘11∘126∘136∘183, 51∘183∘134∘126 -> 51∘64∘11∘136
│  │  │  │  ├─ 51∘126, 51∘183∘134 -> 51∘183∘134∘126
│  │  │  │  │  ⋮
│  │  │  │  │  
│  │  │  │  └─ 82∘71∘136∘134∘126∘64∘115∘11∘183, 115∘82∘183∘71 -> 64∘134∘11∘126∘136∘183
│  │  │  │     ⋮
│  │  │  │     
│  │  │  └─ 30∘51∘12, 30∘136 -> 51∘136∘12
│  │  │     ├─ 30∘136
│  │  │     └─ 30∘51, 12∘30 -> 30∘51∘12
│  │  │        ⋮
│  │  │        
│  │  └─ 11∘12
│  └─ 12∘64, 64 -> 64∘12
│     ├─ 64
│     └─ 12∘64
└─ 12
)

julia> timespace_complexity(optcode_, uniformsize(code, 2))

julia> timespace_complexity(optcode_loaded, uniformsize(code, 2))
(29.762953599372096, 21.0)
```

## Data format
```julia
julia> optcode
1∘3, 3∘4 -> 1∘4
├─ 3∘4
└─ 1∘2, 2∘3 -> 1∘3
   ├─ 2∘3
   └─ 1∘2


julia> writejson("_local/test.json", optcode)
```
Will generate the following file
```json
{
    "output": [
        1,
        4
    ],
    "tree": {
        "isleaf": false,
        "eins": {
            "ixs": [
                [
                    1,
                    3
                ],
                [
                    3,
                    4
                ]
            ],
            "iy": [
                1,
                4
            ]
        },
        "args": [
            {
                "isleaf": false,
                "eins": {
                    "ixs": [
                        [
                            1,
                            2
                        ],
                        [
                            2,
                            3
                        ]
                    ],
                    "iy": [
                        1,
                        3
                    ]
                },
                "args": [
                    {
                        "isleaf": true,
                        "tensorindex": 1
                    },
                    {
                        "isleaf": true,
                        "tensorindex": 2
                    }
                ]
            },
            {
                "isleaf": true,
                "tensorindex": 3
            }
        ]
    },
    "label-type": "Int64",
    "inputs": [
        [
            1,
            2
        ],
        [
            2,
            3
        ],
        [
            3,
            4
        ]
    ]
}
```

* `root["label-type"]` is the data type for labels.
* `root["inputs"]` are vectors of labels for input tensors.
* `root["output"]` are labels for the output tensor.
* `root["tree"]` specifies the nested einsum (a contraction tree).
* `eins` is the einsum code for a single step contraction, its siblings `ixs` are inputs, which is a vector of vector, `iy` is the output, which is a vector.
* `args` specifies the input arguments, which is a vector of leaf nodes or non-leaf nodes. For leaf nodes, we use `tensorindex` to specify a tensor in the `inputs`, a non-leaf nodes is specified as a nested einsum (subtree).
* 
## How to benchmark
```julia
julia> using CUDA, BenchmarkTools
[ Info: OMEinsum loaded the CUDA module successfully

julia> @benchmark CUDA.@sync optcode_loaded([CUDA.rand(fill(2, length(ix))...) for ix in getixsv(optcode_loaded)]...)
BenchmarkTools.Trial: 12 samples with 1 evaluation.
 Range (min … max):  417.572 ms … 485.062 ms  ┊ GC (min … max): 2.28% … 4.11%
 Time  (median):     441.641 ms               ┊ GC (median):    4.45%
 Time  (mean ± σ):   444.844 ms ±  24.147 ms  ┊ GC (mean ± σ):  3.69% ± 1.22%

  █ █ ██  █  █                   █  █ █      █           █    █  
  █▁█▁██▁▁█▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁█▁█▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁█ ▁
  418 ms           Histogram: frequency by time          485 ms <

 Memory estimate: 42.38 MiB, allocs estimate: 739486.
```