### PR TITLE
A new method for the greedy optimizer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,4 +31,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TropicalNumbers = "b3a74e9c-7526-4576-a4eb-79c0d4c32334"
 
 [targets]
-test = ["Test", "Random", "Graphs", "TropicalNumbers", "OMEinsum"]
+test = ["Test", "Random", "Graphs", "TropicalNumbers", "OMEinsum", "KaHyPar"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,9 @@ version = "0.8.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
-BetterExp = "7cffe744-45fd-4178-b173-cf893948b8b7"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 
 [weakdeps]
@@ -18,7 +18,6 @@ KaHyParExt = ["KaHyPar"]
 
 [compat]
 AbstractTrees = "0.3, 0.4"
-BetterExp = "0.1"
 JSON = "0.21"
 KaHyPar = "0.3"
 Suppressor = "0.2"
@@ -32,4 +31,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TropicalNumbers = "b3a74e9c-7526-4576-a4eb-79c0d4c32334"
 
 [targets]
-test = ["Test", "Random", "Graphs", "TropicalNumbers", "OMEinsum", "KaHyPar"]
+test = ["Test", "Random", "Graphs", "TropicalNumbers", "OMEinsum"]

--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ JSON = "0.21"
 KaHyPar = "0.3"
 Suppressor = "0.2"
 julia = "1.9"
+StatsBase = "0.34"
 
 [extras]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"

--- a/Project.toml
+++ b/Project.toml
@@ -20,9 +20,9 @@ KaHyParExt = ["KaHyPar"]
 AbstractTrees = "0.3, 0.4"
 JSON = "0.21"
 KaHyPar = "0.3"
+StatsBase = "0.34"
 Suppressor = "0.2"
 julia = "1.9"
-StatsBase = "0.34"
 
 [extras]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"

--- a/src/OMEinsumContractionOrders.jl
+++ b/src/OMEinsumContractionOrders.jl
@@ -9,7 +9,7 @@ using AbstractTrees
 
 export CodeOptimizer, CodeSimplifier,
     KaHyParBipartite, GreedyMethod, TreeSA, SABipartite,
-    MinSpaceDiff, MinSpaceOut, HyperGreedy,
+    Greedy, MinSpaceDiff, MinSpaceOut, 
     MergeGreedy, MergeVectors,
     uniformsize,
     simplify_code, optimize_code, optimize_permute,

--- a/src/OMEinsumContractionOrders.jl
+++ b/src/OMEinsumContractionOrders.jl
@@ -9,7 +9,7 @@ using AbstractTrees
 
 export CodeOptimizer, CodeSimplifier,
     KaHyParBipartite, GreedyMethod, TreeSA, SABipartite,
-    MinSpaceDiff, MinSpaceOut,
+    MinSpaceDiff, MinSpaceOut, HyperGreedy,
     MergeGreedy, MergeVectors,
     uniformsize,
     simplify_code, optimize_code, optimize_permute,

--- a/src/OMEinsumContractionOrders.jl
+++ b/src/OMEinsumContractionOrders.jl
@@ -9,7 +9,7 @@ using AbstractTrees
 
 export CodeOptimizer, CodeSimplifier,
     KaHyParBipartite, GreedyMethod, TreeSA, SABipartite,
-    Greedy, MinSpaceDiff, MinSpaceOut, 
+    GreedyStrategy, MinSpaceDiff, MinSpaceOut, 
     MergeGreedy, MergeVectors,
     uniformsize,
     simplify_code, optimize_code, optimize_permute,

--- a/src/OMEinsumContractionOrders.jl
+++ b/src/OMEinsumContractionOrders.jl
@@ -9,7 +9,6 @@ using AbstractTrees
 
 export CodeOptimizer, CodeSimplifier,
     KaHyParBipartite, GreedyMethod, TreeSA, SABipartite,
-    GreedyStrategy, MinSpaceDiff, MinSpaceOut, 
     MergeGreedy, MergeVectors,
     uniformsize,
     simplify_code, optimize_code, optimize_permute,

--- a/src/OMEinsumContractionOrders.jl
+++ b/src/OMEinsumContractionOrders.jl
@@ -2,8 +2,8 @@ module OMEinsumContractionOrders
 
 using JSON
 using SparseArrays
+using StatsBase
 using Base: RefValue
-using BetterExp
 using Base.Threads
 using AbstractTrees
 

--- a/src/greedy.jl
+++ b/src/greedy.jl
@@ -6,6 +6,15 @@ end
 struct MinSpaceOut end
 struct MinSpaceDiff end
 
+
+"""
+    LegInfo{ET}
+
+    A struct to store the information of legs in a pairwise contraction between vertices `vi` and `vj`.
+    *`l*` are the legs that are not connected to the other vertex (internal legs)
+    *`l0*` are the legs that are connected to other vertices (external legs)
+    *`*1` are the legs that are connected only to `vi`, and `*2` are the legs that are connected only to `vj`, and `*12` are the legs that are connected to both.
+"""
 struct LegInfo{ET}
     l1::Vector{ET}
     l2::Vector{ET}

--- a/src/greedy.jl
+++ b/src/greedy.jl
@@ -3,14 +3,14 @@ struct ContractionTree
     right
 end
 
-```
+"""
     Greedy{TA, TT}
     * `α` is the parameter for the loss function, for pairwise interaction, L = size(out) - α * (size(in1) + size(in2))
     * `tempareture` is the parameter for sampling, if it is zero, the minimum loss is selected; for non-zero, the loss is selected by the Boltzmann distribution, given by p ~ exp(-loss/tempareture).
 
     MinSpaceOut() = Greedy(0.0, 0.0)
     MinSpaceDiff() = Greedy(1.0, 0.0)
-```
+"""
 struct Greedy{TA, TT}
     α::TA
     tempareture::TT

--- a/src/greedy.jl
+++ b/src/greedy.jl
@@ -4,20 +4,20 @@ struct ContractionTree
 end
 
 """
-    Greedy{TA, TT}
+    GreedyStrategy{TA, TT}
     * `α` is the parameter for the loss function, for pairwise interaction, L = size(out) - α * (size(in1) + size(in2))
     * `tempareture` is the parameter for sampling, if it is zero, the minimum loss is selected; for non-zero, the loss is selected by the Boltzmann distribution, given by p ~ exp(-loss/tempareture).
 
     MinSpaceOut() = Greedy(0.0, 0.0)
     MinSpaceDiff() = Greedy(1.0, 0.0)
 """
-struct Greedy{TA, TT}
+struct GreedyStrategy{TA, TT}
     α::TA
     tempareture::TT
 end
 
-MinSpaceOut() = Greedy(0.0, 0.0)
-MinSpaceDiff() = Greedy(1.0, 0.0)
+MinSpaceOut() = GreedyStrategy(0.0, 0.0)
+MinSpaceDiff() = GreedyStrategy(1.0, 0.0)
 
 
 struct LegInfo{ET}
@@ -161,7 +161,7 @@ function update_costs!(cost_values, va, vb, method, incidence_list::IncidenceLis
     end
 end
 
-function find_best_cost(method::Greedy, cost_values::Dict{PT}) where PT
+function find_best_cost(method::GreedyStrategy, cost_values::Dict{PT}) where PT
     length(cost_values) < 1 && error("cost value information missing")
     if iszero(method.tempareture)
         minval = minimum(Base.values(cost_values))
@@ -217,7 +217,7 @@ function analyze_contraction(incidence_list::IncidenceList{VT,ET}, vi::VT, vj::V
     return LegInfo(leg1, leg2, leg12, leg01, leg02, leg012)
 end
 
-function greedy_loss(method::Greedy, incidence_list, log2_edge_sizes, vi, vj)
+function greedy_loss(method::GreedyStrategy, incidence_list, log2_edge_sizes, vi, vj)
     log2dim(legs) = isempty(legs) ? 0 : sum(l->log2_edge_sizes[l], legs)  # for 1.5, you need this patch because `init` kw is not allowed.
     legs = analyze_contraction(incidence_list, vi, vj)
     D1,D2,D12,D01,D02,D012 = log2dim.(getfield.(Ref(legs), 1:6))
@@ -325,10 +325,10 @@ end
 
 The fast but poor greedy optimizer. Input arguments are
 
-* `method` is `MinSpaceDiff()`, `MinSpaceOut()` or `Greedy(α, tempareture)`.
+* `method` is `MinSpaceDiff()`, `MinSpaceOut()` or `GreedyStrategy(α, tempareture)`.
     * `MinSpaceOut` choose one of the contraction that produces a minimum output tensor size,
     * `MinSpaceDiff` choose one of the contraction that decrease the space most.
-    * `Greedy(α, tempareture)` is the generalized greedy method, where
+    * `GreedyStrategy(α, tempareture)` is the generalized greedy method, where
         * `α` is the parameter for the loss function, for pairwise interaction, L = size(out) - α * (size(in1) + size(in2))
         * `tempareture` is the parameter for sampling, if it is zero, the minimum loss is selected; for non-zero, the loss is selected by the Boltzmann distribution, given by p ~ exp(-loss/tempareture).
 * `nrepeat` is the number of repeatition, returns the best contraction order.

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -51,7 +51,7 @@ function _optimize_code(code, size_dict, optimizer::KaHyParBipartite)
     recursive_bipartite_optimize(optimizer, code, size_dict)
 end
 function _optimize_code(code, size_dict, optimizer::GreedyMethod)
-    optimize_greedy(code, size_dict; method=optimizer.method, nrepeat=optimizer.nrepeat)
+    optimize_greedy(code, size_dict; α = optimizer.α, temperature = optimizer.temperature, nrepeat=optimizer.nrepeat)
 end
 function _optimize_code(code, size_dict, optimizer::SABipartite)
     recursive_bipartite_optimize(optimizer, code, size_dict)
@@ -60,5 +60,5 @@ function _optimize_code(code, size_dict, optimizer::TreeSA)
     optimize_tree(code, size_dict; sc_target=optimizer.sc_target, βs=optimizer.βs,
         ntrials=optimizer.ntrials, niters=optimizer.niters, nslices=optimizer.nslices,
         sc_weight=optimizer.sc_weight, rw_weight=optimizer.rw_weight, initializer=optimizer.initializer,
-        greedy_method=optimizer.greedy_config.method, greedy_nrepeat=optimizer.greedy_config.nrepeat, fixed_slices=optimizer.fixed_slices)
+        greedy_method=optimizer.greedy_config, fixed_slices=optimizer.fixed_slices)
 end

--- a/src/kahypar.jl
+++ b/src/kahypar.jl
@@ -17,11 +17,11 @@ Then finds the contraction order inside each group with the greedy search algori
 * [Hyper-optimized tensor network contraction](https://arxiv.org/abs/2002.01935)
 * [Simulating the Sycamore quantum supremacy circuits](https://arxiv.org/abs/2103.03074)
 """
-Base.@kwdef struct KaHyParBipartite{RT,IT,GM} <: CodeOptimizer
+Base.@kwdef struct KaHyParBipartite{RT,IT,SO} <: CodeOptimizer
     sc_target::RT
     imbalances::IT = 0.0:0.005:0.8
     max_group_size::Int = 40
-    greedy_config::GM = GreedyMethod()
+    sub_optimizer::SO = GreedyMethod()
 end
 
 function induced_subhypergraph(s::SparseMatrixCSC, group)
@@ -58,7 +58,8 @@ function bipartition_recursive(bipartiter, adj::SparseMatrixCSC, vertices::Abstr
         end
         newparts = [bipartition_recursive(bipartiter, adj, groups[i], log2_sizes) for i=1:length(groups)]
         if length(groups) > 2
-            tree = coarse_grained_optimize(adj, groups, log2_sizes, bipartiter.greedy_config)
+            # number of groups is small (2 or 3), thus I think it is not necessary to use more complex methods.
+            tree = coarse_grained_optimize(adj, groups, log2_sizes, GreedyMethod())
             return map_tree_to_parts(tree, newparts)
         else
             return newparts
@@ -92,10 +93,18 @@ function push_connected!(set, visit_mask, adj, i)
     end
 end
 
-function coarse_grained_optimize(adj, parts, log2_sizes, greedy_config)
+# parts are vectors of Ts
+function coarse_grained_optimize(adj, parts, log2_sizes, sub_optimizer)
     incidence_list = get_coarse_grained_graph(adj, parts)
     log2_edge_sizes = Dict([i=>log2_sizes[i] for i=1:length(log2_sizes)])
-    tree, _, _ = tree_greedy(incidence_list, log2_edge_sizes; method=greedy_config.method, nrepeat=greedy_config.nrepeat)
+    tree, _, _ = tree_greedy(incidence_list, log2_edge_sizes; α = sub_optimizer.α, temperature = sub_optimizer.temperature, nrepeat=sub_optimizer.nrepeat)
+
+    # eincode = optimize_code(parse_eincode(incidence_list, tree, vertices=1:length(parts)), log2_sizes, sub_optimizer)
+    # if eincode isa SlicedEinsum
+    #     @assert eincode.slicing == 0
+    #     eincode = eincode.eins
+    # end
+    # tree = parse_tree(eincode, collect(1:length(parts)))
     return tree
 end
 
@@ -139,8 +148,8 @@ end
 Optimize the einsum `code` contraction order using the KaHyPar + Greedy approach. `size_dict` is a dictionary that specifies leg dimensions. 
 Check the docstring of `KaHyParBipartite` for detailed explaination of other input arguments.
 """
-function optimize_kahypar(code::EinCode, size_dict; sc_target, max_group_size=40, imbalances=0.0:0.01:0.2, greedy_method=MinSpaceOut(), greedy_nrepeat=10)
-    bipartiter = KaHyParBipartite(; sc_target=sc_target, max_group_size=max_group_size, imbalances=imbalances, greedy_config=GreedyMethod(method=greedy_method, nrepeat=greedy_nrepeat))
+function optimize_kahypar(code::EinCode, size_dict; sc_target, max_group_size=40, imbalances=0.0:0.01:0.2, sub_optimizer=GreedyMethod())
+    bipartiter = KaHyParBipartite(; sc_target=sc_target, max_group_size=max_group_size, imbalances=imbalances, sub_optimizer = sub_optimizer)
     recursive_bipartite_optimize(bipartiter, code, size_dict)
 end
 
@@ -150,7 +159,7 @@ function recursive_bipartite_optimize(bipartiter, code::EinCode, size_dict)
     adj, edges = adjacency_matrix(ixv)
     vertices=collect(1:length(ixs))
     parts = bipartition_recursive(bipartiter, adj, vertices, [log2(size_dict[e]) for e in edges])
-    recursive_construct_nestedeinsum(ixv, iy, parts, size_dict, 0, bipartiter.greedy_config)
+    recursive_construct_nestedeinsum(ixv, iy, parts, size_dict, 0, bipartiter.sub_optimizer)
 end
 
 maplocs(ne::NestedEinsum{ET}, parts) where ET = isleaf(ne) ? NestedEinsum{ET}(parts[ne.tensorindex]) : NestedEinsum(maplocs.(ne.args, Ref(parts)), ne.eins)
@@ -172,52 +181,57 @@ recursive_flatten(obj) = obj
 Find the optimal contraction order automatically by determining the `sc_target` with bisection.
 It can fail if the tree width of your graph is larger than `100`.
 """
-function optimize_kahypar_auto(code::EinCode, size_dict; max_group_size=40, effort=500, greedy_method=MinSpaceOut(), greedy_nrepeat=10)
+function optimize_kahypar_auto(code::EinCode, size_dict; max_group_size=40, effort=500, sub_optimizer=GreedyMethod())
     sc_high = 100
     sc_low = 1
-    order_high = optimize_kahypar(code, size_dict; sc_target=sc_high, max_group_size=max_group_size, imbalances=0.0:0.6/effort*(sc_high-sc_low):0.6)
-    _optimize_kahypar_auto(code, size_dict, sc_high, order_high, sc_low, max_group_size, effort, greedy_method, greedy_nrepeat)
+    order_high = optimize_kahypar(code, size_dict; sc_target=sc_high, max_group_size=max_group_size, imbalances=0.0:0.6/effort*(sc_high-sc_low):0.6, sub_optimizer = sub_optimizer)
+    _optimize_kahypar_auto(code, size_dict, sc_high, order_high, sc_low, max_group_size, effort, sub_optimizer)
 end
-function _optimize_kahypar_auto(code::EinCode, size_dict, sc_high, order_high, sc_low, max_group_size, effort, greedy_method, greedy_nrepeat)
+function _optimize_kahypar_auto(code::EinCode, size_dict, sc_high, order_high, sc_low, max_group_size, effort, sub_optimizer)
     if sc_high <= sc_low + 1
         order_high
     else
         sc_mid = (sc_high + sc_low) ÷ 2
         try
-            order_mid = optimize_kahypar(code, size_dict; sc_target=sc_mid, max_group_size=max_group_size, imbalances=0.0:0.6/effort*(sc_high-sc_low):0.6)
+            order_mid = optimize_kahypar(code, size_dict; sc_target=sc_mid, max_group_size=max_group_size, imbalances=0.0:0.6/effort*(sc_high-sc_low):0.6, sub_optimizer = sub_optimizer)
             order_high, sc_high = order_mid, sc_mid
             # `sc_target` too high
         catch
             # `sc_target` too low
             sc_low = sc_mid
         end
-        _optimize_kahypar_auto(code, size_dict, sc_high, order_high, sc_low, max_group_size, effort, greedy_method, greedy_nrepeat)
+        _optimize_kahypar_auto(code, size_dict, sc_high, order_high, sc_low, max_group_size, effort, sub_optimizer)
     end
 end
 
-function recursive_construct_nestedeinsum(ixs::AbstractVector{<:AbstractVector}, iy::AbstractVector{L}, parts::AbstractVector, size_dict, level, greedy_config) where L
+function recursive_construct_nestedeinsum(ixs::AbstractVector{<:AbstractVector}, iy::AbstractVector{L}, parts::AbstractVector, size_dict, level, sub_optimizer) where L
     if length(parts) == 2
         # code is a nested einsum
-        code1 = recursive_construct_nestedeinsum(ixs, iy, parts[1], size_dict, level+1, greedy_config)
-        code2 = recursive_construct_nestedeinsum(ixs, iy, parts[2], size_dict, level+1, greedy_config)
+        code1 = recursive_construct_nestedeinsum(ixs, iy, parts[1], size_dict, level+1, sub_optimizer)
+        code2 = recursive_construct_nestedeinsum(ixs, iy, parts[2], size_dict, level+1, sub_optimizer)
         AB = recursive_flatten(parts[2]) ∪ recursive_flatten(parts[1])
         inset12, outset12 = ixs[AB], ixs[setdiff(1:length(ixs), AB)]
         iy12 = Iterators.flatten(inset12) ∩  (Iterators.flatten(outset12) ∪ iy)
         iy1, iy2 = getiyv(code1.eins), getiyv(code2.eins)
         return NestedEinsum([code1, code2], EinCode([iy1, iy2], L[(level==0 ? iy : iy12)...]))
     elseif length(parts) == 1
-        return recursive_construct_nestedeinsum(ixs, iy, parts[1], size_dict, level, greedy_config)
+        return recursive_construct_nestedeinsum(ixs, iy, parts[1], size_dict, level, sub_optimizer)
     else
         error("not a bipartition, got size $(length(parts))")
     end
 end
 
-function recursive_construct_nestedeinsum(ixs::AbstractVector{<:AbstractVector}, iy::AbstractVector{L}, parts::AbstractVector{<:Integer}, size_dict, level, greedy_config) where L
+function recursive_construct_nestedeinsum(ixs::AbstractVector{<:AbstractVector}, iy::AbstractVector{L}, parts::AbstractVector{<:Integer}, size_dict, level, sub_optimizer) where L
     if isempty(parts)
         error("got empty group!")
     end
     inset, outset = ixs[parts], ixs[setdiff(1:length(ixs), parts)]
     iy1 = level == 0 ? iy : Iterators.flatten(inset) ∩  (Iterators.flatten(outset) ∪ iy)
-    res = optimize_greedy(inset, iy1, size_dict; method=greedy_config.method, nrepeat=greedy_config.nrepeat)
+    res = optimize_code(EinCode(inset, iy1), size_dict, sub_optimizer)
+    if res isa SlicedEinsum
+        @assert length(res.slicing) == 0
+        res = res.eins
+    end
+    # res = optimize_greedy(inset, iy1, size_dict; method=greedy_config.method, nrepeat=greedy_config.nrepeat)
     return maplocs(res, parts)
 end

--- a/src/kahypar.jl
+++ b/src/kahypar.jl
@@ -98,13 +98,6 @@ function coarse_grained_optimize(adj, parts, log2_sizes, sub_optimizer)
     incidence_list = get_coarse_grained_graph(adj, parts)
     log2_edge_sizes = Dict([i=>log2_sizes[i] for i=1:length(log2_sizes)])
     tree, _, _ = tree_greedy(incidence_list, log2_edge_sizes; α = sub_optimizer.α, temperature = sub_optimizer.temperature, nrepeat=sub_optimizer.nrepeat)
-
-    # eincode = optimize_code(parse_eincode(incidence_list, tree, vertices=1:length(parts)), log2_sizes, sub_optimizer)
-    # if eincode isa SlicedEinsum
-    #     @assert eincode.slicing == 0
-    #     eincode = eincode.eins
-    # end
-    # tree = parse_tree(eincode, collect(1:length(parts)))
     return tree
 end
 
@@ -176,7 +169,7 @@ recursive_flatten(obj::AbstractVector) = vcat(recursive_flatten.(obj)...)
 recursive_flatten(obj) = obj
 
 """
-    optimize_kahypar_auto(code, size_dict; max_group_size=40, greedy_method=MinSpaceOut(), greedy_nrepeat=10)
+    optimize_kahypar_auto(code, size_dict; max_group_size=40, sub_optimizer = GreedyMethod())
 
 Find the optimal contraction order automatically by determining the `sc_target` with bisection.
 It can fail if the tree width of your graph is larger than `100`.
@@ -232,6 +225,5 @@ function recursive_construct_nestedeinsum(ixs::AbstractVector{<:AbstractVector},
         @assert length(res.slicing) == 0
         res = res.eins
     end
-    # res = optimize_greedy(inset, iy1, size_dict; method=greedy_config.method, nrepeat=greedy_config.nrepeat)
     return maplocs(res, parts)
 end

--- a/src/sa.jl
+++ b/src/sa.jl
@@ -20,14 +20,14 @@ Then finds the contraction order inside each group with the greedy search algori
 ### References
 * [Hyper-optimized tensor network contraction](https://arxiv.org/abs/2002.01935)
 """
-Base.@kwdef struct SABipartite{RT,BT,GM} <: CodeOptimizer
+Base.@kwdef struct SABipartite{RT,BT,SO} <: CodeOptimizer
     sc_target::RT = 25
     ntrials::Int = 50  # number of trials
     βs::BT = 0.1:0.2:15.0  # temperatures
     niters::Int = 1000  # number of iterations in each temperature
     max_group_size::Int = 40
     # configure greedy algorithm
-    greedy_config::GM = GreedyMethod()
+    sub_optimizer::SO = GreedyMethod()
     initializer::Symbol = :random
 end
 
@@ -181,7 +181,7 @@ function initialize_greedy(adj, vertices, log2_sizes)
     incidence_list = IncidenceList(v2e; openedges=openedges)
     log2_edge_sizes = Dict([i=>log2_sizes[i] for i=1:length(log2_sizes)])
     # nrepeat=3 because there are overheads
-    tree, _, _ = tree_greedy(incidence_list, log2_edge_sizes; method=MinSpaceOut(), nrepeat=3)
+    tree, _, _ = tree_greedy(incidence_list, log2_edge_sizes; nrepeat=3)
 
     # build configuration from the tree
     res = ones(Int, size(adj, 1))
@@ -213,10 +213,10 @@ Check the docstring of `SABipartite` for detailed explaination of other input ar
 * [Hyper-optimized tensor network contraction](https://arxiv.org/abs/2002.01935)
 """
 function optimize_sa(code::EinCode, size_dict; sc_target, max_group_size=40,
-             βs=0.01:0.02:15.0, niters=1000, ntrials=50, greedy_method=MinSpaceOut(), greedy_nrepeat=10,
+             βs=0.01:0.02:15.0, niters=1000, ntrials=50, sub_optimizer=GreedyMethod(),
              initializer=:random)
     bipartiter = SABipartite(; sc_target=sc_target, βs=βs, niters=niters, ntrials=ntrials,
-        greedy_config=GreedyMethod(method=greedy_method, nrepeat=greedy_nrepeat),
+    sub_optimizer=sub_optimizer,
         max_group_size=max_group_size, initializer=initializer)
     recursive_bipartite_optimize(bipartiter, code, size_dict)
 end

--- a/src/sa.jl
+++ b/src/sa.jl
@@ -14,7 +14,7 @@ Then finds the contraction order inside each group with the greedy search algori
 * `βs` is a list of inverse temperature `1/T`,
 * `niters` is the number of iteration in each temperature,
 * `ntrials` is the number of repetition (with different random seeds),
-* `greedy_config` configures the greedy method,
+* `sub_optimizer`, the optimizer for the bipartited sub graphs, one can choose `GreedyMethod()` or `TreeSA()`,
 * `initializer`, the partition configuration initializer, one can choose `:random` or `:greedy` (slow but better).
 
 ### References
@@ -203,7 +203,7 @@ end
 # legacy interface
 """
     optimize_sa(code, size_dict; sc_target, max_group_size=40, βs=0.1:0.2:15.0, niters=1000, ntrials=50,
-            greedy_method=MinSpaceOut(), greedy_nrepeat=10, initializer=:random)
+           sub_optimizer = GreedyMethod(), initializer=:random)
 
 Optimize the einsum `code` contraction order using the Simulated Annealing bipartition + Greedy approach.
 `size_dict` is a dictionary that specifies leg dimensions. 

--- a/src/sa.jl
+++ b/src/sa.jl
@@ -72,9 +72,9 @@ function bipartite_sc(bipartiter::SABipartite, adj::SparseMatrixCSC, vertices, l
             newloss = compute_loss(sc_ti, sc_tinew, state.group_sizes[ti]-1, state.group_sizes[3-ti]+1)
             sc_ti0, sc_tinew0 = state.group_scs[ti], state.group_scs[3-ti]
             accept = if max(sc_ti0, sc_tinew0) <= bipartiter.sc_target
-                max(sc_ti, sc_tinew) <= bipartiter.sc_target && (rand() < BetterExp.exp2(β*(state.loss[] - newloss)))
+                max(sc_ti, sc_tinew) <= bipartiter.sc_target && (rand() < exp2(β*(state.loss[] - newloss)))
             else
-                rand() < BetterExp.exp2(-β*(max(sc_ti, sc_tinew) - max(sc_ti0, sc_tinew0)))
+                rand() < exp2(-β*(max(sc_ti, sc_tinew) - max(sc_ti0, sc_tinew0)))
             end
             accept && update_state!(state, adjt, vertices, idxi, sc_ti, sc_tinew, newloss)
         end

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -36,7 +36,7 @@ function merge_greedy(code::EinCode{LT}, size_dict; threshhold=-1e-12) where LT
         return collect(vertices(incidence_list))[1]
     end
     tree = Dict{Int,NestedEinsum}([v=>NestedEinsum{LT}(v) for v in vertices(incidence_list)])
-    cost_values = evaluate_costs(MinSpaceDiff(), incidence_list, log2_edge_sizes)
+    cost_values = evaluate_costs(1.0, incidence_list, log2_edge_sizes)
     while true
         if length(cost_values) == 0
             return _buildsimplifier(tree, incidence_list)
@@ -48,7 +48,7 @@ function merge_greedy(code::EinCode{LT}, size_dict; threshhold=-1e-12) where LT
             if nv(incidence_list) <= 1
                 return _buildsimplifier(tree, incidence_list)
             end
-            update_costs!(cost_values, pair..., MinSpaceDiff(), incidence_list, log2_edge_sizes)
+            update_costs!(cost_values, pair..., 1.0, incidence_list, log2_edge_sizes)
         else
             return _buildsimplifier(tree, incidence_list)
         end

--- a/src/treesa.jl
+++ b/src/treesa.jl
@@ -177,7 +177,7 @@ end
 
 # this is the main function
 """
-    optimize_tree(code, size_dict; sc_target=20, βs=0.1:0.1:10, ntrials=2, niters=100, sc_weight=1.0, rw_weight=0.2, initializer=:greedy, greedy_method=MinSpaceOut(), greedy_nrepeat=1, fixed_slices=[])
+    optimize_tree(code, size_dict; sc_target=20, βs=0.1:0.1:10, ntrials=2, niters=100, sc_weight=1.0, rw_weight=0.2, initializer=:greedy, greedy_method=MinSpaceOut(), fixed_slices=[])
 
 Optimize the einsum contraction pattern specified by `code`, and edge sizes specified by `size_dict`.
 Check the docstring of [`TreeSA`](@ref) for detailed explaination of other input arguments.

--- a/test/greedy.jl
+++ b/test/greedy.jl
@@ -60,6 +60,7 @@ end
 end
 
 @testset "fullerene" begin
+    Random.seed!(123)
     function fullerene()
         φ = (1+√5)/2
         res = NTuple{3,Float64}[]
@@ -112,8 +113,8 @@ end
     @test flatten(optcode) == code
     @test flatten(code) == code
 
-    optcode_hyper = optimize_greedy(code, size_dict, method = Greedy(0.0, 100.0))
+    optcode_hyper = optimize_greedy(code, size_dict, method = Greedy(0.0, 100.0), nrepeat = 20)
     cc3 = contraction_complexity(optcode_hyper, edge_sizes)
-    @test cc3.sc == 10
+    @test cc3.sc <= 12
     @test flatten(optcode_hyper) == code
 end

--- a/test/greedy.jl
+++ b/test/greedy.jl
@@ -1,6 +1,6 @@
 using OMEinsumContractionOrders
 using OMEinsumContractionOrders: analyze_contraction, contract_pair!, evaluate_costs, contract_tree!, log2sumexp2, parse_tree
-using OMEinsumContractionOrders: IncidenceList, neighbors, analyze_contraction, LegInfo, tree_greedy, parse_eincode, optimize_greedy
+using OMEinsumContractionOrders: IncidenceList, analyze_contraction, LegInfo, tree_greedy, parse_eincode, optimize_greedy
 using TropicalNumbers
 
 using Test, Random
@@ -109,7 +109,11 @@ end
     optcode = optimize_greedy(code, size_dict)
     cc2 = contraction_complexity(optcode, edge_sizes)
     @test cc2.sc == 10
-    xs = vcat([TropicalF64.([-1 1; 1 -1]) for i=1:90], [TropicalF64.([0, 0]) for i=1:60])
     @test flatten(optcode) == code
     @test flatten(code) == code
+
+    optcode_hyper = optimize_greedy(code, size_dict, method = HyperGreedy(0.1))
+    cc3 = contraction_complexity(optcode_hyper, edge_sizes)
+    @test cc3.sc == 10
+    @test flatten(optcode_hyper) == code
 end

--- a/test/greedy.jl
+++ b/test/greedy.jl
@@ -51,12 +51,6 @@ end
     @test 16 <= cc.tc <= log2(exp2(10)+exp2(16)+exp2(15)+exp2(9))
     @test cc.sc == 11
     @test optcode1 == optcode2
-
-    # eincode3 = ein"(ab,acd),bcef,e,df->"
-    # Random.seed!(2)
-    # optcode3 = optimize_greedy(eincode3, size_dict) 
-    # tc, sc = timespace_complexity(optcode3, edge_sizes)
-    # @test 16 <= tc <= log2(exp2(10)+exp2(16)+exp2(15)+exp2(9)+1e-8)
 end
 
 @testset "fullerene" begin

--- a/test/greedy.jl
+++ b/test/greedy.jl
@@ -29,7 +29,7 @@ end
         @test sort(target.e2v[k]) == sort(v)
     end
     costs = evaluate_costs(MinSpaceOut(), incidence_list, log2_edge_sizes)
-    @test costs == Dict(('A', 'B')=>9, ('A', 'C')=>15, ('B','C')=>18, ('B','E')=>10, ('C','D')=>11, ('C', 'E')=>14)
+    @test costs == Dict(('A', 'B')=>(2^9), ('A', 'C')=>2^15, ('B','C')=>2^18, ('B','E')=>2^10, ('C','D')=>2^11, ('C', 'E')=>2^14)
     tree, log2_tcs, log2_scs = tree_greedy(incidence_list, log2_edge_sizes)
     tcs_, scs_ = [], []
     contract_tree!(copy(incidence_list), tree, log2_edge_sizes, tcs_, scs_)
@@ -112,7 +112,7 @@ end
     @test flatten(optcode) == code
     @test flatten(code) == code
 
-    optcode_hyper = optimize_greedy(code, size_dict, method = HyperGreedy(0.1))
+    optcode_hyper = optimize_greedy(code, size_dict, method = Greedy(0.0, 100.0))
     cc3 = contraction_complexity(optcode_hyper, edge_sizes)
     @test cc3.sc == 10
     @test flatten(optcode_hyper) == code

--- a/test/greedy.jl
+++ b/test/greedy.jl
@@ -44,12 +44,12 @@ end
     size_dict = Dict([c=>(1<<i) for (i,c) in enumerate(['a', 'b', 'c', 'd', 'e', 'f'])]...)
     Random.seed!(2)
     optcode2 = optimize_greedy(eincode, size_dict) 
-    tc, sc = timespace_complexity(optcode2, edge_sizes)
+    cc = contraction_complexity(optcode2, edge_sizes)
     # test flop
-    @test tc ≈ log2(flop(optcode2, edge_sizes))
+    @test cc.tc ≈ log2(flop(optcode2, edge_sizes))
     @test flop(OMEinsumContractionOrders.EinCode([['i']], Vector{Char}()), Dict('i'=>4)) == 4
-    @test 16 <= tc <= log2(exp2(10)+exp2(16)+exp2(15)+exp2(9))
-    @test sc == 11
+    @test 16 <= cc.tc <= log2(exp2(10)+exp2(16)+exp2(15)+exp2(9))
+    @test cc.sc == 11
     @test optcode1 == optcode2
 
     # eincode3 = ein"(ab,acd),bcef,e,df->"
@@ -103,57 +103,13 @@ end
     size_dict = Dict([i=>2 for i in 1:60])
     log2_edge_sizes = Dict([i=>1 for i in 1:60])
     edge_sizes = Dict([i=>2 for i in 1:60])
-    tc, sc = timespace_complexity(code, edge_sizes)
-    @test tc == 60
-    @test sc == 0
+    cc = contraction_complexity(code, edge_sizes)
+    @test cc.tc == 60
+    @test cc.sc == 0
     optcode = optimize_greedy(code, size_dict)
-    tc2, sc2 = timespace_complexity(optcode, edge_sizes)
-    @test sc2 == 10
+    cc2 = contraction_complexity(optcode, edge_sizes)
+    @test cc2.sc == 10
     xs = vcat([TropicalF64.([-1 1; 1 -1]) for i=1:90], [TropicalF64.([0, 0]) for i=1:60])
     @test flatten(optcode) == code
     @test flatten(code) == code
-    # @test optcode(xs...)[].n == 66
 end
-
-# The following tests are based on the OMEinsum instead of OMEinsumContractionOrders, no fixed yet
-
-# @testset "regression test" begin
-#     code = EinCode([['i']], Vector{Char}())
-#     optcode = optimize_greedy(code, Dict('i'=>3))
-#     @test optcode isa NestedEinsum
-#     x = randn(3)
-#     @test optcode(x) ≈ code(x)
-
-#     code = ein"i,j->"
-#     optcode = optimize_greedy(code, Dict('i'=>3, 'j'=>3))
-#     @test optcode isa NestedEinsum
-#     x = randn(3)
-#     y = randn(3)
-#     @test optcode(x, y) ≈ code(x, y)
-
-#     code = ein"ij,jk,kl->ijl"
-#     optcode = optimize_greedy(code, Dict('i'=>3, 'j'=>3, 'k'=>3, 'l'=>3))
-#     @test optcode isa NestedEinsum
-#     a, b, c = [rand(3,3) for i=1:3]
-#     @test optcode(a, b, c) ≈ code(a, b, c)
-# end
-
-# @testset "constructing contraction tree manually" begin
-#     code = ein"ij,jk,kl->ijl"
-#     dcode = DynamicEinCode(ein"ij,jk,kl->ijl")
-#     a, b, c = randn(2, 2), randn(2,2), randn(2,2)
-#     ne1 = parse_nested(code, ContractionTree(ContractionTree(1, 2), 3))
-#     ne2 = parse_nested(dcode, ContractionTree(ContractionTree(1, 2), 3))
-#     ne3 = parse_nested(code, ContractionTree(ContractionTree(1, 3), 2))
-#     @test typeof(ne1) == NestedEinsum{StaticEinCode}
-#     @test typeof(ne2) == NestedEinsum{DynamicEinCode{Char}}
-#     @test ne1(a,b,c) ≈ ein"(ij,jk),kl->ijl"(a,b,c)
-#     @test ne2(a,b,c) ≈ ein"(ij,jk),kl->ijl"(a,b,c)
-#     @test ne3(a,b,c) ≈ ein"(ij,jk),kl->ijl"(a,b,c)
-#     @test flop(code, Dict([l=>2 for l in uniquelabels(code)])) == 2^4
-#     @test flop(ne1, Dict([l=>2 for l in uniquelabels(code)])) == 2^4 + 2^3
-#     @test flop(ne2, Dict([l=>2 for l in uniquelabels(code)])) == 2^4 + 2^3
-
-#     # label elimination order
-#     @test label_elimination_order(ein"(ij,jk),kl->il") == ['j', 'k']
-# end

--- a/test/greedy.jl
+++ b/test/greedy.jl
@@ -113,7 +113,7 @@ end
     @test flatten(optcode) == code
     @test flatten(code) == code
 
-    optcode_hyper = optimize_greedy(code, size_dict, method = Greedy(0.0, 100.0), nrepeat = 20)
+    optcode_hyper = optimize_greedy(code, size_dict, method = GreedyStrategy(0.0, 100.0), nrepeat = 20)
     cc3 = contraction_complexity(optcode_hyper, edge_sizes)
     @test cc3.sc <= 12
     @test flatten(optcode_hyper) == code

--- a/test/greedy.jl
+++ b/test/greedy.jl
@@ -28,7 +28,7 @@ end
     for (k,v) in il.e2v
         @test sort(target.e2v[k]) == sort(v)
     end
-    costs = evaluate_costs(MinSpaceOut(), incidence_list, log2_edge_sizes)
+    costs = evaluate_costs(0.0, incidence_list, log2_edge_sizes)
     @test costs == Dict(('A', 'B')=>(2^9), ('A', 'C')=>2^15, ('B','C')=>2^18, ('B','E')=>2^10, ('C','D')=>2^11, ('C', 'E')=>2^14)
     tree, log2_tcs, log2_scs = tree_greedy(incidence_list, log2_edge_sizes)
     tcs_, scs_ = [], []
@@ -113,7 +113,7 @@ end
     @test flatten(optcode) == code
     @test flatten(code) == code
 
-    optcode_hyper = optimize_greedy(code, size_dict, method = GreedyStrategy(0.0, 100.0), nrepeat = 20)
+    optcode_hyper = optimize_greedy(code, size_dict, α = 0.0, temperature = 100.0, nrepeat = 20)
     cc3 = contraction_complexity(optcode_hyper, edge_sizes)
     @test cc3.sc <= 12
     @test flatten(optcode_hyper) == code

--- a/test/kahypar.jl
+++ b/test/kahypar.jl
@@ -81,7 +81,7 @@ end
     Random.seed!(2)
     code = random_regular_eincode(220, 3)
     codeg_auto = optimize_kahypar_auto(code, uniformsize(code, 2), sub_optimizer=GreedyMethod())
-    codet_auto = optimize_kahypar_auto(code, uniformsize(code, 2), sub_optimizer=TreeSA(ntrials = 4, sc_weight = 0.1))
+    codet_auto = optimize_kahypar_auto(code, uniformsize(code, 2), sub_optimizer=TreeSA(ntrials = 1, sc_weight = 0.1))
     ccg = contraction_complexity(codeg_auto, uniformsize(code, 2))
     @show ccg.sc, ccg.tc
     cct = contraction_complexity(codet_auto, uniformsize(code, 2))

--- a/test/kahypar.jl
+++ b/test/kahypar.jl
@@ -3,7 +3,7 @@ using Test, Random
 using SparseArrays
 using OMEinsumContractionOrders
 using OMEinsumContractionOrders: get_coarse_grained_graph, _connected_components, bipartite_sc, group_sc, coarse_grained_optimize,
-    map_tree_to_parts, MinSpaceOut, ContractionTree, optimize_greedy, optimize_kahypar, optimize_kahypar_auto
+    map_tree_to_parts, ContractionTree, optimize_greedy, optimize_kahypar, optimize_kahypar_auto
 using KaHyPar
 using OMEinsum: decorate
 
@@ -22,7 +22,7 @@ using OMEinsum: decorate
 
     @test length(_connected_components(adj, parts[1])) == 2
 
-    res = coarse_grained_optimize(adj, parts, ones(6), GreedyMethod(MinSpaceOut(), 10))
+    res = coarse_grained_optimize(adj, parts, ones(6), GreedyMethod())
     @test res == ContractionTree(ContractionTree(1,2), 3)
     @test map_tree_to_parts(res, [[[1,2], 3], [7,6], [9, [4,1]]]) == [[[[1,2], 3], [7,6]], [9, [4,1]]]
 end
@@ -56,15 +56,23 @@ end
 
     code = random_regular_eincode(220, 3)
     res = optimize_kahypar(code,uniformsize(code, 2); max_group_size=50, sc_target=30)
-    tc, sc = timespace_complexity(res, uniformsize(code, 2))
-    @test sc <= 30
+    cc = contraction_complexity(res, uniformsize(code, 2))
+    @test cc.sc <= 30
 
     # contraction test
     code = random_regular_eincode(50, 3)
-    codeg = optimize_kahypar(code, uniformsize(code, 2); max_group_size=10, sc_target=12)
+    codeg = optimize_kahypar(code, uniformsize(code, 2); max_group_size=10, sc_target=10)
+    codet = optimize_kahypar(code, uniformsize(code, 2); max_group_size=10, sc_target=10, sub_optimizer = TreeSA())
     codek = optimize_greedy(code, uniformsize(code, 2))
-    tc, sc = timespace_complexity(codek, uniformsize(code, 2))
-    @test sc <= 12
+
+    cc_kg = contraction_complexity(codeg, uniformsize(code, 2))
+    cc_kt = contraction_complexity(codet, uniformsize(code, 2))
+    cc_g = contraction_complexity(codek, uniformsize(code, 2))
+
+    @test cc_kg.sc <= 12
+    @test cc_kt.sc <= 12
+    @test cc_g.sc <= 12
+
     xs = [[2*randn(2, 2) for i=1:75]..., [randn(2) for i=1:50]...]
     resg = decorate(codeg)(xs...)
     resk = decorate(codek)(xs...)
@@ -72,7 +80,13 @@ end
 
     Random.seed!(2)
     code = random_regular_eincode(220, 3)
-    codeg_auto = optimize_kahypar_auto(code, uniformsize(code, 2), greedy_method=MinSpaceOut())
-    tc, sc = timespace_complexity(codeg_auto, uniformsize(code, 2))
-    @test sc <= 30
+    codeg_auto = optimize_kahypar_auto(code, uniformsize(code, 2), sub_optimizer=GreedyMethod())
+    codet_auto = optimize_kahypar_auto(code, uniformsize(code, 2), sub_optimizer=TreeSA(ntrials = 4, sc_weight = 0.1))
+    ccg = contraction_complexity(codeg_auto, uniformsize(code, 2))
+    @show ccg.sc, ccg.tc
+    cct = contraction_complexity(codet_auto, uniformsize(code, 2))
+    @show cct.sc, cct.tc
+
+    @test ccg.sc <= 30
+    @test cct.sc <= 30
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,26 +5,26 @@ using Test
     include("greedy.jl")
 end
 
+@testset "sa" begin
+    include("sa.jl")
+end
+
 @testset "kahypar" begin
     include("kahypar.jl")
 end
-
-# @testset "sa" begin
-#     include("sa.jl")
-# end
 
 @testset "treesa" begin
     include("treesa.jl")
 end
 
-# @testset "simplify" begin
-#     include("simplify.jl")
-# end
+@testset "simplify" begin
+    include("simplify.jl")
+end
 
-# @testset "interfaces" begin
-#     include("interfaces.jl")
-# end
+@testset "interfaces" begin
+    include("interfaces.jl")
+end
 
-# @testset "json" begin
-#     include("json.jl")
-# end
+@testset "json" begin
+    include("json.jl")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,22 +9,22 @@ end
     include("kahypar.jl")
 end
 
-@testset "sa" begin
-    include("sa.jl")
-end
+# @testset "sa" begin
+#     include("sa.jl")
+# end
 
 @testset "treesa" begin
     include("treesa.jl")
 end
 
-@testset "simplify" begin
-    include("simplify.jl")
-end
+# @testset "simplify" begin
+#     include("simplify.jl")
+# end
 
-@testset "interfaces" begin
-    include("interfaces.jl")
-end
+# @testset "interfaces" begin
+#     include("interfaces.jl")
+# end
 
-@testset "json" begin
-    include("json.jl")
-end
+# @testset "json" begin
+#     include("json.jl")
+# end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,10 @@
 using OMEinsumContractionOrders
 using Test
 
+@testset "greedy" begin
+    include("greedy.jl")
+end
+
 @testset "kahypar" begin
     include("kahypar.jl")
 end

--- a/test/sa.jl
+++ b/test/sa.jl
@@ -45,8 +45,8 @@ end
 
     code = random_regular_eincode(220, 3)
     res = optimize_sa(code,uniformsize(code, 2); sc_target=30, βs=βs)
-    tc, sc = timespace_complexity(res, uniformsize(code, 2))
-    @test sc <= 32
+    cc = contraction_complexity(res, uniformsize(code, 2))
+    @test cc.sc <= 32
 
     tc1, sc1, rw1 = timespacereadwrite_complexity(res, uniformsize(code, 2))
     cc = contraction_complexity(res, uniformsize(code, 2))
@@ -57,8 +57,8 @@ end
     code = random_regular_eincode(50, 3)
     codeg = optimize_sa(code, uniformsize(code, 2); sc_target=12, βs=βs, ntrials=1, initializer=:greedy)
     codek = optimize_greedy(code, uniformsize(code, 2))
-    tc, sc = timespace_complexity(codek, uniformsize(code, 2))
-    @test sc <= 12
+    cc = contraction_complexity(codek, uniformsize(code, 2))
+    @test cc.sc <= 12
     xs = [[2*randn(2, 2) for i=1:75]..., [randn(2) for i=1:50]...]
     resg = decorate(codeg)(xs...)
     resk = decorate(codek)(xs...)


### PR DESCRIPTION
The following changes have been made in this PR:
1. Added a new optimizer "Hyper-Greedy". In each step, instead of directly selecting the contraction pair with the lowest cost, here we sampling one of them according to the cost $\exp(-L / t)$, where $L$ is the cost and $t$ is the temperature, thus it may given better results that greedy.
2. Deps of `BetterExp` is removed, since it has been merge to `Base` since `Julia@1.6`, and currently `exp2` provided by `Base` seems better:
```
julia> @btime exp2(1.0);
  0.791 ns (0 allocations: 0 bytes)

julia> @btime BetterExp.exp2(1.0);
  1.625 ns (0 allocations: 0 bytes)

(betterexp) pkg> st
Status `~/temp/betterexp/Project.toml`
  [6e4b80f9] BenchmarkTools v1.5.0
  [7cffe744] BetterExp v0.1.0
```

3. Added multi-threads support for `tree_greedy`.