### PR TITLE
revise the ExactTreeWidth solver with TreeWidthSolver 0.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ KaHyPar = "0.3"
 StatsBase = "0.34"
 Suppressor = "0.2"
 LuxorGraphPlot = "0.5.1"
-TreeWidthSolver = "0.1.0"
+TreeWidthSolver = "0.2"
 julia = "1.9"
 
 [extras]

--- a/src/treewidth.jl
+++ b/src/treewidth.jl
@@ -55,9 +55,11 @@ ab, ab -> a
 """
 function exact_treewidth_method(incidence_list::IncidenceList{VT,ET}, log2_edge_sizes; α::TA = 0.0, temperature::TT = 0.0, nrepeat=1) where {VT,ET,TA,TT}
     indicies = collect(keys(incidence_list.e2v))
+    tensors = collect(keys(incidence_list.v2e))
     weights = [log2_edge_sizes[e] for e in indicies]
     line_graph = il2lg(incidence_list, indicies)
 
+    scalars = [i for i in tensors if isempty(incidence_list.v2e[i])]
     contraction_trees = Vector{Union{ContractionTree, VT}}()
 
     # avoid the case that the line graph is not connected
@@ -71,8 +73,9 @@ function exact_treewidth_method(incidence_list::IncidenceList{VT,ET}, log2_edge_
         contraction_tree = eo2ct(elimination_order, incidence_list, log2_edge_sizes, α, temperature, nrepeat)
         push!(contraction_trees, contraction_tree)
     end
-    
-    return reduce((x,y) -> ContractionTree(x, y), contraction_trees)
+
+    # add the scalars back to the contraction tree
+    return reduce((x,y) -> ContractionTree(x, y), contraction_trees ∪ scalars)
 end
 
 # transform incidence list to line graph

--- a/test/treewidth.jl
+++ b/test/treewidth.jl
@@ -34,4 +34,10 @@ using Test, Random
     cc = contraction_complexity(optcode, size_dict)
     @test cc.sc == 7
     @test decorate(eincode)(tensors...) ≈ decorate(optcode)(tensors...)
+
+    eincode = OMEinsumContractionOrders.EinCode([['a', 'b'], ['a', 'c', 'd'], ['b', 'c', 'e'], ['e'], ['f'], Char[]], ['a', 'f'])
+    tensors = tensors ∪ fill(2.0,())
+    optcode = optimize_exact_treewidth(optimizer, eincode, size_dict)
+    cc = contraction_complexity(optcode, size_dict)
+    @test decorate(eincode)(tensors...) ≈ decorate(optcode)(tensors...)
 end

--- a/test/treewidth.jl
+++ b/test/treewidth.jl
@@ -36,7 +36,7 @@ using Test, Random
     @test decorate(eincode)(tensors...) ≈ decorate(optcode)(tensors...)
 
     eincode = OMEinsumContractionOrders.EinCode([['a', 'b'], ['a', 'c', 'd'], ['b', 'c', 'e'], ['e'], ['f'], Char[]], ['a', 'f'])
-    tensors = tensors ∪ fill(2.0,())
+    tensors = tensors ∪ [fill(2.0,())]
     optcode = optimize_exact_treewidth(optimizer, eincode, size_dict)
     cc = contraction_complexity(optcode, size_dict)
     @test decorate(eincode)(tensors...) ≈ decorate(optcode)(tensors...)


### PR DESCRIPTION
In TreeWidthSolver.jl 0.2.0, the `EliminationOrder` contains the information about which indices are eliminated together. 
The solver `ExactTreeWidth()` has been revised to work with the new `EliminationOrder`.