### PR TITLE
Preprocessing for `ExactTreewidth` 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,9 +33,6 @@ Suppressor = "0.2"
 TreeWidthSolver = "0.3"
 julia = "1.8"
 
-[sources]
-CliqueTrees = {path="../CliqueTrees.jl"}
-
 [extras]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 KaHyPar = "2a6221f6-aa48-11e9-3542-2d9e0ef01880"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.9.5"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+CliqueTrees = "60701a23-6482-424a-84db-faee86b9b1f8"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -22,6 +23,7 @@ LuxorTensorPlot = ["LuxorGraphPlot"]
 
 [compat]
 AbstractTrees = "0.3, 0.4"
+CliqueTrees = "1.3.0"
 DataStructures = "0.18"
 JSON = "0.21"
 KaHyPar = "0.3"
@@ -30,6 +32,9 @@ StatsBase = "0.34"
 Suppressor = "0.2"
 TreeWidthSolver = "0.3"
 julia = "1.8"
+
+[sources]
+CliqueTrees = {path="../CliqueTrees.jl"}
 
 [extras]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"

--- a/src/OMEinsumContractionOrders.jl
+++ b/src/OMEinsumContractionOrders.jl
@@ -9,6 +9,7 @@ using AbstractTrees
 using TreeWidthSolver
 using TreeWidthSolver.Graphs
 using DataStructures: PriorityQueue, enqueue!, dequeue!, peek, dequeue_pair!
+using CliqueTrees: cliquetree, residual, BT, RuleReduction
 
 export CodeOptimizer, CodeSimplifier,
     KaHyParBipartite, GreedyMethod, TreeSA, SABipartite, ExactTreewidth,


### PR DESCRIPTION
This PR adds a preprocessing step to the `ExactTreewidth` algorithm. Here are some benchmarks.

```julia-repl
julia> using OMEinsumContractionOrders, Graphs, Random

julia> using OMEinsumContractionOrders: EinCode

julia> Random.seed!(100);

julia> function random_regular_eincode(n, k; optimize=nothing)
           g = Graphs.random_regular_graph(n, k)
           ixs = [[minmax(e.src,e.dst)...] for e in Graphs.edges(g)]
           return EinCode([ixs..., [[i] for i in Graphs.vertices(g)]...], Int[])
       end;

julia> code = random_regular_eincode(30, 3);
```

**without reduction**

```julia-repl
julia> @time optimize_code(code, uniformsize(code, 2), ExactTreewidth());
  7.071026 seconds (45.66 M allocations: 4.509 GiB, 3.71% gc time)
```

**with reduction**

```julia-repl
julia> @time optimize_code(code, uniformsize(code, 2), ExactTreewidth());
  1.700728 seconds (12.48 M allocations: 1.152 GiB, 5.23% gc time)
```

See also [this issue](https://github.com/ArrogantGao/TreeWidthSolver.jl/issues/20).


