### PR TITLE
Update tree width solvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,42 +12,7 @@ To install OMEinsumContractionOrders, please follow these steps:
 1. Open Julia's interactive session (known as [REPL](https://docs.julialang.org/en/v1/manual/getting-started/)) by typing `julia` in your terminal.
 2. Press the <kbd>]</kbd> key in the REPL to enter the package mode.
 3. Type `add OMEinsumContractionOrders` to install the stable release of the package.
-4. (Optional) If you want to use the `KaHyParBipartite` optimizer, which is based on the KaHyPar library, type `add KaHyPar`. Note that this step is optional because some users may have issues with the binary dependencies of KaHyPar (please check issues: [this](https://github.com/kahypar/KaHyPar.jl/issues/12) and [this](https://github.com/kahypar/KaHyPar.jl/issues/19)).
-
-## Example 1: Use it directly
-The contraction order optimizer is implemented in the `optimize_code` function. It takes three arguments: `code`, `size`, and `optimizer`. The `code` argument is the [einsum notation](https://numpy.org/doc/stable/reference/generated/numpy.einsum.html) to be optimized. The `size` argument is the size of the variables in the einsum notation. The `optimizer` argument is the optimizer to be used. The `optimize_code` function returns the optimized contraction order. One can use `contraction_complexity` function to get the time, space and rewrite complexity of returned contraction order.
-
-```julia
-julia> using OMEinsumContractionOrders, Graphs, KaHyPar
-
-julia> function random_regular_eincode(n, k; optimize=nothing)
-	    g = Graphs.random_regular_graph(n, k)
-	    ixs = [[minmax(e.src,e.dst)...] for e in Graphs.edges(g)]
-	    return EinCode([ixs..., [[i] for i in Graphs.vertices(g)]...], Int[])
-    end
-    
-julia> code = random_regular_eincode(200, 3);
-
-julia> optcode_tree = optimize_code(code, uniformsize(code, 2),
-	TreeSA(sc_target=28, βs=0.1:0.1:10, ntrials=2, niters=100, sc_weight=3.0));
-
-julia> contraction_complexity(optcode_tree, uniformsize(code, 2))
-Time complexity: 2^39.5938886486877
-Space complexity: 2^28.0
-Read-write complexity: 2^30.39890775966298
-```
-
-`OMEinsumContractionOrders` is shipped with [`OMEinsum`](https://github.com/under-Peter/OMEinsum.jl) package. You can use it to optimize the contraction order of a `OMEinsum` expression.
 
 ## References
 
 If you find this package useful in your research, please cite the *relevant* papers in [CITATION.bib](CITATION.bib).
-
-## Multi-GPU computation
-Please check this Gist:
-
-https://gist.github.com/GiggleLiu/d5b66c9883f0c5df41a440589983ab99
-
-## Authors
-
-OMEinsumContractionOrders was developed by Jin-Guo Liu and Pan Zhang.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,6 +22,6 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/GiggleLiu/OMEinsumContractionOrders.jl",
+    repo="github.com/TensorBFS/OMEinsumContractionOrders.jl",
     devbranch="master",
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,10 +4,10 @@ CurrentModule = OMEinsumContractionOrders
 
 # OMEinsumContractionOrders
 
-This is the documentation for [OMEinsumContractionOrders](https://github.com/GiggleLiu/OMEinsumContractionOrders.jl),
+This is the documentation for [OMEinsumContractionOrders](https://github.com/TensorBFS/OMEinsumContractionOrders.jl),
 a Julia package for the optimization of the contraction order of tensor networks.
 
-**Installation** guide is available in [README.md](https://github.com/GiggleLiu/OMEinsumContractionOrders.jl). You can also access its features in [OMEinsum](https://github.com/under-Peter/OMEinsum.jl), which uses it as the default contraction order optimizer.
+**Installation** guide is available in [README.md](https://github.com/TensorBFS/OMEinsumContractionOrders.jl). You can also access its features in [OMEinsum](https://github.com/under-Peter/OMEinsum.jl), which uses it as the default contraction order optimizer.
 
 ## Example 1: Use it directly
 The contraction order optimizer is implemented in the [`optimize_code`](@ref) function. It takes three arguments: `code`, `size`, and `optimizer`. The `code` argument is the [einsum notation](https://numpy.org/doc/stable/reference/generated/numpy.einsum.html) to be optimized. The `size` argument is the size of the variables in the einsum notation. The `optimizer` argument is the optimizer to be used. The `optimize_code` function returns the optimized contraction order. One can use [`contraction_complexity`](@ref) function to get the time, space and rewrite complexity of returned contraction order.
@@ -18,8 +18,10 @@ Supported solvers include:
 | [`GreedyMethod`](@ref) | Fast, but poor resulting order |
 | [`TreeSA`](@ref) | Reliable, local search based optimizer [^Kalachev2021], but is a bit slow |
 | [`KaHyParBipartite`](@ref) and [`SABipartite`](@ref) | Graph bipartition based, suited for large tensor networks [^Gray2021], requires using [`KaHyPar`](https://github.com/kahypar/KaHyPar.jl) package |
-| [`ExactTreewidth`](@ref) | Exact, but takes exponential time [^Bouchitté2001], based on package [`TreeWidthSolver`](https://github.com/ArrogantGao/TreeWidthSolver.jl) |
+| [`Treewidth`](@ref) | Tree width solver based, based on package [`CliqueTrees`](https://github.com/AlgebraicJulia/CliqueTrees.jl), performance is elimination algorithm dependent |
+| [`ExactTreewidth`](@ref) (alias of `Treewidth{RuleReduction{BT}}`) | Exact, but takes exponential time [^Bouchitté2001], based on package [`TreeWidthSolver`](https://github.com/ArrogantGao/TreeWidthSolver.jl) |
 
+The `KaHyParBipartite` is implemented as an extension. If you have issues in installing `KaHyPar`, please check these issues: [#12](https://github.com/kahypar/KaHyPar.jl/issues/12) and [#19](https://github.com/kahypar/KaHyPar.jl/issues/19).
 Additionally, code simplifiers can be used to preprocess the tensor network to reduce the optimization time:
 
 | Simplifier | Description |
@@ -68,6 +70,8 @@ code = ein"ij, jk, kl, il->"
 optimized_code = optimize_code(code, uniformsize(code, 2), TreeSA())
 ```
 
+For multi-GPU contraction of tensor networks, please check [this Gist](https://gist.github.com/GiggleLiu/d5b66c9883f0c5df41a440589983ab99).
+
 ## Example 3: Visualization
 
 ### LuxorTensorPlot
@@ -109,9 +113,11 @@ julia> viz_contraction(nested_code)
 ```
 
 The resulting image and video will be saved in the current working directory, and the image is shown below:
+```@raw html
 <div style="text-align:center">
 	<img src="assets/eins.png" alt="Image" width="40%" />
 </div>
+```
 The large white nodes represent the tensors, and the small colored nodes represent the indices, red for closed indices and green for open indices.
 
 [^Bouchitté2001]: Bouchitté, V., Todinca, I., 2001. Treewidth and Minimum Fill-in: Grouping the Minimal Separators. SIAM J. Comput. 31, 212–232. https://doi.org/10.1137/S0097539799359683

--- a/src/OMEinsumContractionOrders.jl
+++ b/src/OMEinsumContractionOrders.jl
@@ -9,10 +9,10 @@ using AbstractTrees
 using TreeWidthSolver
 using TreeWidthSolver.Graphs
 using DataStructures: PriorityQueue, enqueue!, dequeue!, peek, dequeue_pair!
-using CliqueTrees: cliquetree, residual, BT, RuleReduction, MF
+using CliqueTrees: cliquetree, residual, EliminationAlgorithm, BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, BT, MinimalChordal, CompositeRotations, RuleReduction, ComponentReduction
 
 export CodeOptimizer, CodeSimplifier,
-    KaHyParBipartite, GreedyMethod, TreeSA, SABipartite, ExactTreewidth,
+    KaHyParBipartite, GreedyMethod, TreeSA, SABipartite, Treewidth, ExactTreewidth,
     MergeGreedy, MergeVectors,
     uniformsize,
     simplify_code, optimize_code, optimize_permute,

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -6,7 +6,7 @@ Returns a `NestedEinsum` instance. Input arguments are
 
 * `eincode` is an einsum contraction code instance, one of `DynamicEinCode`, `StaticEinCode` or `NestedEinsum`.
 * `size` is a dictionary of "edge label=>edge size" that contains the size information, one can use `uniformsize(eincode, 2)` to create a uniform size.
-* `optimizer` is a `CodeOptimizer` instance, should be one of `GreedyMethod`, `ExactTreewidth`, `KaHyParBipartite`, `SABipartite` or `TreeSA`. Check their docstrings for details.
+* `optimizer` is a `CodeOptimizer` instance, should be one of `GreedyMethod`, `Treewidth`, `KaHyParBipartite`, `SABipartite` or `TreeSA`. Check their docstrings for details.
 * `simplifier` is one of `MergeVectors` or `MergeGreedy`.
 * optimize the permutation if `permute` is true.
 
@@ -43,8 +43,8 @@ end
 function _optimize_code(code, size_dict, optimizer::GreedyMethod)
     optimize_greedy(code, size_dict; α = optimizer.α, temperature = optimizer.temperature, nrepeat=optimizer.nrepeat)
 end
-function _optimize_code(code, size_dict, optimizer::ExactTreewidth)
-    optimize_exact_treewidth(optimizer, code, size_dict)
+function _optimize_code(code, size_dict, optimizer::Treewidth)
+    optimize_treewidth(optimizer, code, size_dict)
 end
 function _optimize_code(code, size_dict, optimizer::SABipartite)
     recursive_bipartite_optimize(optimizer, code, size_dict)

--- a/src/treewidth.jl
+++ b/src/treewidth.jl
@@ -29,8 +29,7 @@ Detailed descriptions is available in the [CliqueTrees.jl](https://algebraicjuli
 
 # Example
 ```jldoctest
-julia> optimizer = OMEinsumContractionOrders.Treewidth()
-Treewidth{GreedyMethod{Float64, Float64}}(RuleReduction(BT()), GreedyMethod{Float64, Float64}(0.0, 0.0, 1))
+julia> optimizer = Treewidth();
 
 julia> eincode = OMEinsumContractionOrders.EinCode([['a', 'b'], ['a', 'c', 'd'], ['b', 'c', 'e', 'f'], ['e'], ['d', 'f']], ['a'])
 ab, acd, bcef, e, df -> a

--- a/src/treewidth.jl
+++ b/src/treewidth.jl
@@ -1,16 +1,36 @@
 """
-    struct ExactTreewidth{GM} <: CodeOptimizer
-    ExactTreewidth(greedy_config::GM = GreedyMethod(nrepeat=1))
+    struct Treewidth{EL <: EliminationAlgorithm, GM} <: CodeOptimizer
+    Treewidth(; alg::EL = RuleReduction(BT()), greedy_config::GM = GreedyMethod(nrepeat=1))
 
-A optimizer using the exact tree width solver proved in TreeWidthSolver.jl, the greedy_config is the configuration for the greedy method, which is used to solve the subproblems in the tree decomposition.
+Tree width based solver. The solvers are implemented in [CliqueTrees.jl](https://algebraicjulia.github.io/CliqueTrees.jl/stable/) and [TreeWidthSolver.jl](https://github.com/ArrogantGao/TreeWidthSolver.jl). They include:
+
+| Algorithm | Description | Time Complexity | Space Complexity |
+|:-----------|:-------------|:----------------|:-----------------|
+| `BFS` | breadth-first search | O(m + n) | O(n) |
+| `MCS` | maximum cardinality search | O(m + n) | O(n) |
+| `LexBFS` | lexicographic breadth-first search | O(m + n) | O(m + n) |
+| `RCMMD` | reverse Cuthill-Mckee (minimum degree) | O(m + n) | O(m + n) |
+| `RCMGL` | reverse Cuthill-Mckee (George-Liu) | O(m + n) | O(m + n) |
+| `MCSM` | maximum cardinality search (minimal) | O(mn) | O(n) |
+| `LexM` | lexicographic breadth-first search (minimal) | O(mn) | O(n) |
+| `AMF` | approximate minimum fill | O(mn) | O(m + n) |
+| `MF` | minimum fill | O(mn²) | - |
+| `MMD` | multiple minimum degree | O(mn²) | O(m + n) |
+| `MinimalChordal` | MinimalChordal | - | - |
+| `CompositeRotations` | elimination tree rotation | O(m + n) | O(m + n) |
+| `RuleReduction` | treewith-safe rule-based reduction | - | - |
+| `ComponentReduction` | connected component reduction | - | - |
+
+Detailed descriptions is available in the [CliqueTrees.jl](https://algebraicjulia.github.io/CliqueTrees.jl/stable/api/#Elimination-Algorithms).
 
 # Fields
+- `alg::EL`: The algorithm to use for the treewidth calculation. Available elimination algorithms are listed above.
 - `greedy_config::GM`: The configuration for the greedy method.
 
 # Example
 ```jldoctest
-julia> optimizer = OMEinsumContractionOrders.ExactTreewidth()
-ExactTreewidth{GreedyMethod{Float64, Float64}}(GreedyMethod{Float64, Float64}(0.0, 0.0, 1))
+julia> optimizer = OMEinsumContractionOrders.Treewidth()
+Treewidth{GreedyMethod{Float64, Float64}}(RuleReduction(BT()), GreedyMethod{Float64, Float64}(0.0, 0.0, 1))
 
 julia> eincode = OMEinsumContractionOrders.EinCode([['a', 'b'], ['a', 'c', 'd'], ['b', 'c', 'e', 'f'], ['e'], ['d', 'f']], ['a'])
 ab, acd, bcef, e, df -> a
@@ -36,16 +56,28 @@ ab, ab -> a
 └─ ab
 ```
 """
-Base.@kwdef struct ExactTreewidth{GM} <: CodeOptimizer 
+Base.@kwdef struct Treewidth{EL <: EliminationAlgorithm, GM} <: CodeOptimizer 
+    alg::EL = RuleReduction(BT())
     greedy_config::GM = GreedyMethod(nrepeat=1)
 end
+
+"""
+    const ExactTreewidth{GM} = Treewidth{RuleReduction{BT}, GM}
+    ExactTreewidth(; greedy_config = GreedyMethod(nrepeat=1)) = Treewidth(; greedy_config)
+
+`ExactTreewidth` is a specialization of `Treewidth` for the `RuleReduction` algorithm with the `BT` elimination algorithm.
+The `BT` algorithm is an exact solver for the treewidth problem that implemented in [`TreeWidthSolver.jl`](https://github.com/ArrogantGao/TreeWidthSolver.jl).
+"""
+const ExactTreewidth{GM} = Treewidth{RuleReduction{BT}, GM}
+ExactTreewidth(; greedy_config = GreedyMethod(nrepeat=1)) = Treewidth(; greedy_config)
 
 # calculates the exact treewidth of a graph using TreeWidthSolver.jl. It takes an incidence list representation of the graph (`incidence_list`) and a dictionary of logarithm base 2 edge sizes (`log2_edge_sizes`) as input. The function also accepts optional parameters `α`, `temperature`, and `nrepeat` with default values of 0.0, 0.0, and 1 respectively, which are parameter of the GreedyMethod used in the contraction process as a sub optimizer.
 # Return: a `ContractionTree` representing the contraction process.
 #
 # - `incidence_list`: An incidence list representation of the graph.
 # - `log2_edge_sizes`: A dictionary of logarithm base 2 edge sizes.
-function exact_treewidth_method(incidence_list::IncidenceList{VT,ET}, log2_edge_sizes; α::TA = 0.0, temperature::TT = 0.0, nrepeat=1) where {VT,ET,TA,TT}
+# - `alg`: The algorithm to use for the treewidth calculation.
+function treewidth_method(incidence_list::IncidenceList{VT,ET}, log2_edge_sizes, alg; α::TA = 0.0, temperature::TT = 0.0, nrepeat=1) where {VT,ET,TA,TT}
     indices = collect(keys(incidence_list.e2v))
     tensors = collect(keys(incidence_list.v2e))
     weights = [log2_edge_sizes[e] for e in indices]
@@ -61,7 +93,6 @@ function exact_treewidth_method(incidence_list::IncidenceList{VT,ET}, log2_edge_
         lg_weights = weights[vertice_ids]
 
         # construct tree decomposition
-        alg = RuleReduction(BT()) # reduce graph, then call `TreeWidthSolver.elimination_order`
         perm, tree = cliquetree(lg_weights, lg; alg) # `tree` is a vector of cliques
         permute!(lg_indices, perm)                   # `perm` is a permutation
 
@@ -144,15 +175,15 @@ function st2ct(sub_tree::Union{ContractionTree, VT}, tensors_list::Dict{VT, Int}
 end
 
 """
-    optimize_exact_treewidth(optimizer, eincode, size_dict)
+    optimize_treewidth(optimizer, eincode, size_dict)
 
 Optimizing the contraction order via solve the exact tree width of the line graph corresponding to the eincode and return a `NestedEinsum` object.
-Check the docstring of `exact_treewidth_method` for detailed explaination of other input arguments.
+Check the docstring of `treewidth_method` for detailed explaination of other input arguments.
 """
-function optimize_exact_treewidth(optimizer::ExactTreewidth{GM}, code::AbstractEinsum, size_dict::Dict) where {GM}
-    optimize_exact_treewidth(optimizer, getixsv(code), getiyv(code), size_dict)
+function optimize_treewidth(optimizer::Treewidth{EL, GM}, code::AbstractEinsum, size_dict::Dict) where {GM, EL}
+    optimize_treewidth(optimizer, getixsv(code), getiyv(code), size_dict)
 end
-function optimize_exact_treewidth(optimizer::ExactTreewidth{GM}, ixs::AbstractVector{<:AbstractVector}, iy::AbstractVector, size_dict::Dict{L,TI}) where {L, TI, GM}
+function optimize_treewidth(optimizer::Treewidth{EL, GM}, ixs::AbstractVector{<:AbstractVector}, iy::AbstractVector, size_dict::Dict{L,TI}) where {L, TI, GM, EL}
     if length(ixs) <= 2
         return NestedEinsum(NestedEinsum{L}.(1:length(ixs)), EinCode(ixs, iy))
     end
@@ -166,7 +197,7 @@ function optimize_exact_treewidth(optimizer::ExactTreewidth{GM}, ixs::AbstractVe
     α = optimizer.greedy_config.α
     temperature = optimizer.greedy_config.temperature
     nrepeat = optimizer.greedy_config.nrepeat
-    tree = exact_treewidth_method(incidence_list, log2_edge_sizes; α = α, temperature = temperature, nrepeat=nrepeat)
+    tree = treewidth_method(incidence_list, log2_edge_sizes, optimizer.alg; α = α, temperature = temperature, nrepeat=nrepeat)
 
     # remove the dummy tensor added for open edges
     optcode = parse_eincode!(incidence_list, tree, 1:length(ixs) + 1, size_dict)[2]

--- a/test/treewidth.jl
+++ b/test/treewidth.jl
@@ -1,5 +1,6 @@
 using OMEinsumContractionOrders
-using OMEinsumContractionOrders: IncidenceList, optimize_exact_treewidth, getixsv
+using OMEinsumContractionOrders: IncidenceList, optimize_treewidth, getixsv
+using OMEinsumContractionOrders: BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, BT, MinimalChordal, CompositeRotations, RuleReduction, ComponentReduction
 using OMEinsum: decorate
 
 using Test, Random
@@ -11,7 +12,7 @@ using Test, Random
     # eincode with no open edges
     eincode = OMEinsumContractionOrders.EinCode([['a', 'b'], ['a', 'c', 'd'], ['b', 'c', 'e', 'f'], ['e'], ['d', 'f']], Vector{Char}())
     tensors = [rand([size_dict[j] for j in ixs]...) for ixs in getixsv(eincode)]
-    optcode = optimize_exact_treewidth(optimizer, eincode, size_dict)
+    optcode = optimize_treewidth(optimizer, eincode, size_dict)
     cc = contraction_complexity(optcode, size_dict)
     # test flop
     @test cc.tc ≈ log2(flop(optcode, size_dict))
@@ -22,7 +23,7 @@ using Test, Random
     # eincode with open edges
     eincode = OMEinsumContractionOrders.EinCode([['a', 'b'], ['a', 'c', 'd'], ['b', 'c', 'e', 'f'], ['e'], ['d', 'f']], ['a'])
     tensors = [rand([size_dict[j] for j in ixs]...) for ixs in getixsv(eincode)]
-    optcode = optimize_exact_treewidth(optimizer, eincode, size_dict)
+    optcode = optimize_treewidth(optimizer, eincode, size_dict)
     cc = contraction_complexity(optcode, size_dict)
     @test cc.sc == 11
     @test decorate(eincode)(tensors...) ≈ decorate(optcode)(tensors...)
@@ -30,14 +31,14 @@ using Test, Random
     # disconnect contraction tree
     eincode = OMEinsumContractionOrders.EinCode([['a', 'b'], ['a', 'c', 'd'], ['b', 'c', 'e'], ['e'], ['f']], ['a', 'f'])
     tensors = [rand([size_dict[j] for j in ixs]...) for ixs in getixsv(eincode)]
-    optcode = optimize_exact_treewidth(optimizer, eincode, size_dict)
+    optcode = optimize_treewidth(optimizer, eincode, size_dict)
     cc = contraction_complexity(optcode, size_dict)
     @test cc.sc == 7
     @test decorate(eincode)(tensors...) ≈ decorate(optcode)(tensors...)
 
     eincode = OMEinsumContractionOrders.EinCode([['a', 'b'], ['a', 'c', 'd'], ['b', 'c', 'e'], ['e'], ['f'], Char[]], ['a', 'f'])
     tensors = tensors ∪ [fill(2.0,())]
-    optcode = optimize_exact_treewidth(optimizer, eincode, size_dict)
+    optcode = optimize_treewidth(optimizer, eincode, size_dict)
     cc = contraction_complexity(optcode, size_dict)
     @test decorate(eincode)(tensors...) ≈ decorate(optcode)(tensors...)
 end
@@ -49,10 +50,28 @@ end
     eincode = OMEinsumContractionOrders.EinCode([['a', 'b', 'c', 'd', 'e', 'f'], ['e', 'f', 'g', 'h', 'i', 'j'], ['a', 'b', 'c', 'd', 'g', 'h', 'i', 'j']], Vector{Char}())
     ixs = getixsv(eincode)
     tensors = [rand([size_dict[j] for j in ix]...) for ix in ixs]
-    optcode = optimize_exact_treewidth(optimizer, eincode, size_dict)
+    optcode = optimize_treewidth(optimizer, eincode, size_dict)
     incidence_list = IncidenceList(Dict([i=>ix for (i,ix) in enumerate(ixs)] ∪ [(length(ixs) + 1 => eincode.iy)]))
     lg = OMEinsumContractionOrders.il2lg(incidence_list, collect(keys(size_dict)))
     tw = OMEinsumContractionOrders.TreeWidthSolver.exact_treewidth(lg)
     cc = contraction_complexity(optcode, size_dict)
     @test isapprox(cc.tc, tw + 1, atol=0.9)
+end
+
+@testset "treewidth" begin
+    for alg in [RuleReduction(BT()), MF(), MMD(), AMF(), LexM(), LexBFS(), BFS(), MCS(), RCMMD(), RCMGL(), MCSM()]
+        optimizer = Treewidth(alg=alg)
+        size_dict = Dict([c=>(1<<i) for (i,c) in enumerate(['a', 'b', 'c', 'd', 'e', 'f'])]...)
+
+        # eincode with no open edges
+        eincode = OMEinsumContractionOrders.EinCode([['a', 'b'], ['a', 'c', 'd'], ['b', 'c', 'e', 'f'], ['e'], ['d', 'f']], Vector{Char}())
+        tensors = [rand([size_dict[j] for j in ixs]...) for ixs in getixsv(eincode)]
+        optcode = optimize_treewidth(optimizer, eincode, size_dict)
+        cc = contraction_complexity(optcode, size_dict)
+        # test flop
+        @test cc.tc ≈ log2(flop(optcode, size_dict))
+        @test (16 <= cc.tc <= log2(exp2(10)+exp2(16)+exp2(15)+exp2(9))) | (cc.tc ≈ log2(exp2(10)+exp2(16)+exp2(15)+exp2(9)))
+        @test cc.sc == 11
+        @test decorate(eincode)(tensors...) ≈ decorate(optcode)(tensors...)
+    end
 end

--- a/test/treewidth.jl
+++ b/test/treewidth.jl
@@ -2,8 +2,8 @@ using OMEinsumContractionOrders
 using OMEinsumContractionOrders: IncidenceList, optimize_treewidth, getixsv
 using OMEinsumContractionOrders: BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, BT, MinimalChordal, CompositeRotations, RuleReduction, ComponentReduction
 using OMEinsum: decorate
-
 using Test, Random
+
 @testset "tree width" begin
 
     optimizer = ExactTreewidth()


### PR DESCRIPTION
Support multiple backends in CliqueTrees.jl. The following test best summarizes this PR:
```julia
using OMEinsumContractionOrders
using OMEinsumContractionOrders: IncidenceList, optimize_treewidth, getixsv
using OMEinsumContractionOrders: BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, BT, MinimalChordal, CompositeRotations, RuleReduction, ComponentReduction
using Test

@testset "treewidth" begin
    for alg in [RuleReduction(BT()), MF(), MMD(), AMF(), LexM(), LexBFS(), BFS(), MCS(), RCMMD(), RCMGL(), MCSM()]
        optimizer = Treewidth(alg=alg)
        size_dict = Dict([c=>(1<<i) for (i,c) in enumerate(['a', 'b', 'c', 'd', 'e', 'f'])]...)

        # eincode with no open edges
        eincode = OMEinsumContractionOrders.EinCode([['a', 'b'], ['a', 'c', 'd'], ['b', 'c', 'e', 'f'], ['e'], ['d', 'f']], Vector{Char}())
        tensors = [rand([size_dict[j] for j in ixs]...) for ixs in getixsv(eincode)]
        optcode = optimize_treewidth(optimizer, eincode, size_dict)
        cc = contraction_complexity(optcode, size_dict)
        # test flop
        @test cc.tc ≈ log2(flop(optcode, size_dict))
        @test (16 <= cc.tc <= log2(exp2(10)+exp2(16)+exp2(15)+exp2(9))) | (cc.tc ≈ log2(exp2(10)+exp2(16)+exp2(15)+exp2(9)))
        @test cc.sc == 11
        @test decorate(eincode)(tensors...) ≈ decorate(optcode)(tensors...)
    end
end
```

@ArrogantGao Now ExactTreewidth is an alias of Treewidth{RuleReduction(BT())}