### PR TITLE
remove the multi-threading in greedy

### DIFF
--- a/src/greedy.jl
+++ b/src/greedy.jl
@@ -25,7 +25,7 @@ function tree_greedy(incidence_list::IncidenceList{Int, ET}, log2_edge_sizes; α
     @assert nrepeat >= 1
 
     results = Vector{Tuple{ContractionTree, Vector{Float64}, Vector{Float64}}}(undef, nrepeat)
-    @threads for i = 1:nrepeat
+    for i = 1:nrepeat
         results[i] = _tree_greedy(incidence_list, log2_edge_sizes; α = α, temperature = temperature)
     end
 


### PR DESCRIPTION
I find that TreeSA() use the `tree_greedy` function, and using @threads in @threads somehow make it very slow.
Since `greedy` is fast, I remove this multi-threading in it