### PR TITLE
New RuleReduction api.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ LuxorTensorPlot = ["LuxorGraphPlot"]
 
 [compat]
 AbstractTrees = "0.3, 0.4"
-CliqueTrees = "1.3.0"
+CliqueTrees = "1.5.0"
 DataStructures = "0.18"
 Documenter = "1.10.1"
 JSON = "0.21"

--- a/src/OMEinsumContractionOrders.jl
+++ b/src/OMEinsumContractionOrders.jl
@@ -9,7 +9,7 @@ using AbstractTrees
 using TreeWidthSolver
 using TreeWidthSolver.Graphs
 using DataStructures: PriorityQueue, enqueue!, dequeue!, peek, dequeue_pair!
-using CliqueTrees: cliquetree, residual, EliminationAlgorithm, BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, BT, MinimalChordal, CompositeRotations, RuleReduction, ComponentReduction
+using CliqueTrees: cliquetree, residual, EliminationAlgorithm, MMW, BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, MF, BT, SafeRules
 
 export CodeOptimizer, CodeSimplifier,
     KaHyParBipartite, GreedyMethod, TreeSA, SABipartite, Treewidth, ExactTreewidth,

--- a/src/treewidth.jl
+++ b/src/treewidth.jl
@@ -1,6 +1,6 @@
 """
     struct Treewidth{EL <: EliminationAlgorithm, GM} <: CodeOptimizer
-    Treewidth(; alg::EL = RuleReduction(BT()), greedy_config::GM = GreedyMethod(nrepeat=1))
+    Treewidth(; alg::EL = SafeRules(BT(), MMW{3}(), MF()), greedy_config::GM = GreedyMethod(nrepeat=1))
 
 Tree width based solver. The solvers are implemented in [CliqueTrees.jl](https://algebraicjulia.github.io/CliqueTrees.jl/stable/) and [TreeWidthSolver.jl](https://github.com/ArrogantGao/TreeWidthSolver.jl). They include:
 
@@ -16,10 +16,6 @@ Tree width based solver. The solvers are implemented in [CliqueTrees.jl](https:/
 | `AMF` | approximate minimum fill | O(mn) | O(m + n) |
 | `MF` | minimum fill | O(mn²) | - |
 | `MMD` | multiple minimum degree | O(mn²) | O(m + n) |
-| `MinimalChordal` | MinimalChordal | - | - |
-| `CompositeRotations` | elimination tree rotation | O(m + n) | O(m + n) |
-| `RuleReduction` | treewith-safe rule-based reduction | - | - |
-| `ComponentReduction` | connected component reduction | - | - |
 
 Detailed descriptions is available in the [CliqueTrees.jl](https://algebraicjulia.github.io/CliqueTrees.jl/stable/api/#Elimination-Algorithms).
 
@@ -56,18 +52,18 @@ ab, ab -> a
 ```
 """
 Base.@kwdef struct Treewidth{EL <: EliminationAlgorithm, GM} <: CodeOptimizer 
-    alg::EL = RuleReduction(BT())
+    alg::EL = SafeRules(BT(), MMW{3}(), MF())
     greedy_config::GM = GreedyMethod(nrepeat=1)
 end
 
 """
-    const ExactTreewidth{GM} = Treewidth{RuleReduction{BT}, GM}
+    const ExactTreewidth{GM} = Treewidth{SafeRules{BT, MMW{3}(), MF}, GM}
     ExactTreewidth(; greedy_config = GreedyMethod(nrepeat=1)) = Treewidth(; greedy_config)
 
-`ExactTreewidth` is a specialization of `Treewidth` for the `RuleReduction` algorithm with the `BT` elimination algorithm.
+`ExactTreewidth` is a specialization of `Treewidth` for the `SafeRules` preprocessing algorithm with the `BT` elimination algorithm.
 The `BT` algorithm is an exact solver for the treewidth problem that implemented in [`TreeWidthSolver.jl`](https://github.com/ArrogantGao/TreeWidthSolver.jl).
 """
-const ExactTreewidth{GM} = Treewidth{RuleReduction{BT}, GM}
+const ExactTreewidth{GM} = Treewidth{SafeRules{BT, MMW{3}, MF}, GM}
 ExactTreewidth(; greedy_config = GreedyMethod(nrepeat=1)) = Treewidth(; greedy_config)
 
 # calculates the exact treewidth of a graph using TreeWidthSolver.jl. It takes an incidence list representation of the graph (`incidence_list`) and a dictionary of logarithm base 2 edge sizes (`log2_edge_sizes`) as input. The function also accepts optional parameters `α`, `temperature`, and `nrepeat` with default values of 0.0, 0.0, and 1 respectively, which are parameter of the GreedyMethod used in the contraction process as a sub optimizer.

--- a/test/treewidth.jl
+++ b/test/treewidth.jl
@@ -1,6 +1,6 @@
 using OMEinsumContractionOrders
 using OMEinsumContractionOrders: IncidenceList, optimize_treewidth, getixsv
-using OMEinsumContractionOrders: BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, BT, MinimalChordal, CompositeRotations, RuleReduction, ComponentReduction
+using OMEinsumContractionOrders: BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, BT, SafeRules
 using OMEinsum: decorate
 using Test, Random
 
@@ -59,7 +59,7 @@ end
 end
 
 @testset "treewidth" begin
-    for alg in [RuleReduction(BT()), MF(), MMD(), AMF(), LexM(), LexBFS(), BFS(), MCS(), RCMMD(), RCMGL(), MCSM()]
+    for alg in [SafeRules(BT()), MF(), MMD(), AMF(), LexM(), LexBFS(), BFS(), MCS(), RCMMD(), RCMGL(), MCSM()]
         optimizer = Treewidth(alg=alg)
         size_dict = Dict([c=>(1<<i) for (i,c) in enumerate(['a', 'b', 'c', 'd', 'e', 'f'])]...)
 


### PR DESCRIPTION
In CliqueTrees `1.5`, I added a preprocessing step called "graph compression" to the `RuleReduction` algorithm. You can read about it in section 4.3 of this paper, where it is called *Indistinguishable Node Reduction*.

- Ost, Lara, Christian Schulz, and Darren Strash. "Engineering data reduction for nested dissection." 2021 *Proceedings of the Workshop on Algorithm Engineering and Experiments (ALENEX).* Society for Industrial and Applied Mathematics, 2021.

In order to give users more fine-grained control over the algorithm, I also added some additional parameters. I changed the name of the algorithm to `SafeRules` and preserved the old-name as an alias, so this is a **non-breaking change**.

```julia
const RuleReduction{A} = SafeRules{A, MMW{3}, MF}
```

This PR updates OMEinsumContractionOrders so that it uses the new api, which is `SafeRules(alg, lb, ub).`
- `alg` is an elimination algorithm (in your case, `BT`) which is applied after the graph is reduced.
- `lb` is a lower bound algorithm: it computes a lower bound to the treewidth. You can also provide a number.
- `ub` is an elimination algorithm: it computes an upper bound to the treewidth.

The higher the lower bound, the more reductions can be performed. The `ub` algorithm is included as a shortcut: if `lb` and `ub` compute the same number, then the algorithm halts early, without calling `alg`.

