### PR TITLE
Add optimizer `HyperND`.

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,3 +6,6 @@ KaHyPar = "2a6221f6-aa48-11e9-3542-2d9e0ef01880"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 OMEinsum = "ebe7aa44-baf0-506c-a96f-8464559b3922"
 OMEinsumContractionOrders = "6f22d1fd-8eed-4bb7-9776-e7d684900715"
+
+[sources]
+OMEinsumContractionOrders = {path=".."}

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,6 +20,7 @@ Supported solvers include:
 | [`KaHyParBipartite`](@ref) and [`SABipartite`](@ref) | Graph bipartition based, suited for large tensor networks [^Gray2021], requires using [`KaHyPar`](https://github.com/kahypar/KaHyPar.jl) package |
 | [`Treewidth`](@ref) | Tree width solver based, based on package [`CliqueTrees`](https://github.com/AlgebraicJulia/CliqueTrees.jl), performance is elimination algorithm dependent |
 | [`ExactTreewidth`](@ref) (alias of `Treewidth{RuleReduction{BT}}`) | Exact, but takes exponential time [^Bouchitté2001], based on package [`TreeWidthSolver`](https://github.com/ArrogantGao/TreeWidthSolver.jl) |
+| [`HyperND`](@ref) | Nested dissection algorithm, similar to [`KaHyParBipartite`](@ref). Requires imporing either [`KaHyPar`](https://github.com/kahypar/KaHyPar.jl) or [`Metis`](https://github.com/JuliaSparse/Metis.jl). |
 
 The `KaHyParBipartite` is implemented as an extension. If you have issues in installing `KaHyPar`, please check these issues: [#12](https://github.com/kahypar/KaHyPar.jl/issues/12) and [#19](https://github.com/kahypar/KaHyPar.jl/issues/19).
 Additionally, code simplifiers can be used to preprocess the tensor network to reduce the optimization time:

--- a/src/OMEinsumContractionOrders.jl
+++ b/src/OMEinsumContractionOrders.jl
@@ -10,10 +10,10 @@ using TreeWidthSolver
 using TreeWidthSolver.Graphs
 using DataStructures: PriorityQueue, enqueue!, dequeue!, peek, dequeue_pair!
 import CliqueTrees
-using CliqueTrees: cliquetree, residual, EliminationAlgorithm, MMW, BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, MF, BT, SafeRules
+using CliqueTrees: cliquetree, residual, EliminationAlgorithm, MMW, BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, MF, BT, SafeRules, KaHyParND, METISND, ND
 
 export CodeOptimizer, CodeSimplifier,
-    KaHyParBipartite, GreedyMethod, TreeSA, SABipartite, Treewidth, ExactTreewidth,
+    KaHyParBipartite, GreedyMethod, TreeSA, SABipartite, Treewidth, ExactTreewidth, HyperND,
     MergeGreedy, MergeVectors,
     uniformsize,
     simplify_code, optimize_code, optimize_permute,
@@ -41,6 +41,9 @@ include("treesa.jl")
 
 # tree width method
 include("treewidth.jl")
+
+# nested dissection method
+include("hypernd.jl")
 
 # simplification passes
 include("simplify.jl")

--- a/src/hypernd.jl
+++ b/src/hypernd.jl
@@ -1,5 +1,7 @@
 """
-    HyperND(dis, algs;
+    HyperND(;
+        dis = KaHyParND(),
+        algs = (MF(), MMD()),
         level = 6,
         width = 120,
         imbalances = 130:130,
@@ -30,21 +32,12 @@ The optimizer is implemented using the tree decomposition library
   - `imbalances`: imbalance parameters 
 
 """
-struct HyperND{D, A} <: CodeOptimizer
-    dis::D
-    algs::A
-    level::Int
-    width::Int
-    imbalances::StepRange{Int, Int}
-end
-
-function HyperND(dis::D=KaHyParND(), algs::A = (MF(), MMD());
-        level::Integer = 6,
-        width::Integer = 120,
-        imbalances::AbstractRange=130:130,
-    ) where{D, A}
-
-    return HyperND{D, A}(dis, algs, level, width, imbalances)
+@kwdef struct HyperND{D, A} <: CodeOptimizer
+    dis::D = KaHyParND()
+    algs::A = (MF(), MMD())
+    level::Int = 6
+    width::Int = 120
+    imbalances::StepRange{Int, Int} = 130:1:130
 end
 
 function optimize_hyper_nd(optimizer::HyperND, code, size_dict)

--- a/src/hypernd.jl
+++ b/src/hypernd.jl
@@ -72,7 +72,7 @@ function optimize_hyper_nd(optimizer::HyperND, code, size_dict)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", optimizer::HyperND{D, A}) where {D, A}
-    println(io, "HyPar{$D, $A}:")
+    println(io, "HyperND{$D, $A}:")
     show(IOContext(io, :indent => 4), "text/plain", optimizer.dis)
 
     for alg in optimizer.algs

--- a/src/hypernd.jl
+++ b/src/hypernd.jl
@@ -1,0 +1,86 @@
+"""
+    HyperND(dis, algs;
+        level = 6,
+        width = 120,
+        imbalances = 130:130,
+    )
+
+Nested-dissection based optimizer. Recursively partitions a tensor network, then calls a
+greedy algorithm on the leaves. The optimizer is run a number of times: once for each greedy
+algorithm in `algs` and each imbalance value in `imbalances`. The recursion depth is controlled by
+the parameters `level` and `width`.
+
+The line graph is partitioned using the algorithm `dis`. OMEinsumContractionOrders currently supports two partitioning
+algorithms, both of which require importing an external library.
+
+| type                                                                                             | package                                              |
+|:-------------------------------------------------------------------------------------------------|:-----------------------------------------------------|
+| [`METISND`](https://algebraicjulia.github.io/CliqueTrees.jl/stable/api/#CliqueTrees.METISND)     | [Metis.jl](https://github.com/JuliaSparse/Metis.jl)  |
+| [`KaHyParND`](https://algebraicjulia.github.io/CliqueTrees.jl/stable/api/#CliqueTrees.KaHyParND) | [KayHyPar.jl](https://github.com/kahypar/KaHyPar.jl) |
+
+The optimizer is implemented using the tree decomposition library
+[CliqueTrees.jl](https://github.com/AlgebraicJulia/CliqueTrees.jl).
+
+# Arguments
+
+  - `dis`: [graph partitioning algorithm](https://algebraicjulia.github.io/CliqueTrees.jl/stable/api/#CliqueTrees.DissectionAlgorithm)
+  - `algs`: tuple of [elimination algorithms](https://algebraicjulia.github.io/CliqueTrees.jl/stable/api/#Elimination-Algorithms).
+  - `level`: maximum level
+  - `width`: minimum width
+  - `imbalances`: imbalance parameters 
+
+"""
+struct HyperND{D, A} <: CodeOptimizer
+    dis::D
+    algs::A
+    level::Int
+    width::Int
+    imbalances::StepRange{Int, Int}
+end
+
+function HyperND(dis::D=KaHyParND(), algs::A = (MF(), MMD());
+        level::Integer = 6,
+        width::Integer = 120,
+        imbalances::AbstractRange=130:130,
+    ) where{D, A}
+
+    return HyperND{D, A}(dis, algs, level, width, imbalances)
+end
+
+function optimize_hyper_nd(optimizer::HyperND, code, size_dict)
+    dis = optimizer.dis
+    algs = optimizer.algs
+    level = optimizer.level
+    width = optimizer.width
+    imbalances = optimizer.imbalances
+
+    mintc = minsc = minrw = typemax(Float64)
+    mincode = nothing
+
+    for alg in algs, imbalance in imbalances
+        curalg = SafeRules(ND(alg, dis; imbalance))
+        curoptimizer = Treewidth(; alg=curalg)
+        curcode = _optimize_code(code, size_dict, curoptimizer)
+        curtc, cursc, currw = __timespacereadwrite_complexity(curcode, size_dict)
+
+        if minsc > cursc || (minsc == cursc && mintc > curtc) || (minsc == cursc && mintc == curtc && minrw > currw)
+            mintc, minsc, minrw, mincode = curtc, cursc, currw, curcode
+        end
+    end
+
+    return mincode
+end
+
+function Base.show(io::IO, ::MIME"text/plain", optimizer::HyperND{D, A}) where {D, A}
+    println(io, "HyPar{$D, $A}:")
+    show(IOContext(io, :indent => 4), "text/plain", optimizer.dis)
+
+    for alg in optimizer.algs
+        show(IOContext(io, :indent => 4), "text/plain", alg)
+    end
+
+    println(io, "    level: $(optimizer.level)")
+    println(io, "    width: $(optimizer.width)")
+    println(io, "    imbalances: $(optimizer.imbalances)")
+    return
+end

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -55,3 +55,7 @@ function _optimize_code(code, size_dict, optimizer::TreeSA)
         sc_weight=optimizer.sc_weight, rw_weight=optimizer.rw_weight, initializer=optimizer.initializer,
         greedy_method=optimizer.greedy_config, fixed_slices=optimizer.fixed_slices)
 end
+function _optimize_code(code, size_dict, optimizer::HyperND)
+    optimize_hyper_nd(optimizer, code, size_dict)
+end
+

--- a/test/hypernd.jl
+++ b/test/hypernd.jl
@@ -1,0 +1,30 @@
+using Graphs
+using OMEinsumContractionOrders
+using OMEinsumContractionOrders: optimize_hyper_nd
+using Random
+using Test
+
+import KaHyPar
+
+@testset "chain and ring" begin
+    # chain
+    code = OMEinsumContractionOrders.EinCode([[1,2], [2,3], [3,4], [4,5], [5,6], [6,7], [7,8], [8,9], [9,10]], Int[1, 10])
+    size_dict = Dict([i=>2 for i in 1:10])
+    optcode = optimize_hyper_nd(HyperND(; width=5), code, size_dict)
+    cc = contraction_complexity(optcode, size_dict)
+    @test cc.sc == 2
+
+    # ring
+    ring = OMEinsumContractionOrders.EinCode([[1,2], [2,3], [3,4], [4,5], [5,6], [6,7], [7,8], [8,9], [9,10], [10,1]], Int[])
+    optcode = optimize_hyper_nd(HyperND(; width=5), ring, size_dict)
+    cc = contraction_complexity(optcode, size_dict)
+    @test cc.sc == 2
+
+    # petersen
+    graph = smallgraph(:tutte)
+    code = OMEinsumContractionOrders.EinCode([[e.src, e.dst] for e in edges(graph)], Int[])
+    size_dict = Dict([i=>2 for i in 1:nv(graph)])
+    optcode = optimize_hyper_nd(HyperND(; width=5), code, size_dict)
+    cc = contraction_complexity(optcode, size_dict)
+    @test cc.sc == 5
+end

--- a/test/interfaces.jl
+++ b/test/interfaces.jl
@@ -15,7 +15,7 @@ using OMEinsum
     xs = [[randn(2,2) for i=1:150]..., [randn(2) for i=1:100]...]
 
     results = Float64[]
-    for optimizer in [TreeSA(ntrials=1), TreeSA(ntrials=1, nslices=5), GreedyMethod(), SABipartite(sc_target=18, ntrials=1)]
+    for optimizer in [TreeSA(ntrials=1), TreeSA(ntrials=1, nslices=5), GreedyMethod(), SABipartite(sc_target=18, ntrials=1), HyperND()]
         for simplifier in (nothing, MergeVectors(), MergeGreedy())
             @info "optimizer = $(optimizer), simplifier = $(simplifier)"
             res = optimize_code(code,uniformsize(code, 2), optimizer, simplifier)
@@ -42,7 +42,7 @@ using OMEinsum
     xs = [[randn(2,2) for i=1:15]..., [randn(2) for i=1:10]...]
 
     results = Float64[]
-    for optimizer in [TreeSA(ntrials=1), TreeSA(ntrials=1, nslices=5), GreedyMethod(), SABipartite(sc_target=18, ntrials=1), ExactTreewidth()]
+    for optimizer in [TreeSA(ntrials=1), TreeSA(ntrials=1, nslices=5), GreedyMethod(), SABipartite(sc_target=18, ntrials=1), ExactTreewidth(), HyperND()]
         for simplifier in (nothing, MergeVectors(), MergeGreedy())
             @info "optimizer = $(optimizer), simplifier = $(simplifier)"
             res = optimize_code(small_code,uniformsize(small_code, 2), optimizer, simplifier)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,10 @@ end
     include("treewidth.jl")
 end
 
+@testset "hypernd" begin
+    include("hypernd.jl")
+end
+
 @testset "simplify" begin
     include("simplify.jl")
 end


### PR DESCRIPTION
This adds a new optimizer `HyperND`. Works pretty well! When I run it on the [n-Queens example](https://github.com/TensorBFS/OMEinsumContractionOrders.jl/blob/master/examples/nqueens.jl), I get the following.

```julia-repl
julia> import Metis

julia> optimizer = HyperND(METISND(); imbalances=100:5:800)
HyperND{METISND, Tuple{MF, MMD}}:
    METISND:
        nseps: -1
        seed: -1
    MF
    MMD:
        delta: 0
    level: 6
    width: 120
    imbalances: 100:5:800

julia> optcode = optimize_code(code, uniformsize(code, 2), optimizer);

julia> contraction_complexity(optcode, uniformsize(optcode, 2)))
Time complexity: 2^125.66928746222648
Space complexity: 2^88.0
Read-write complexity: 2^91.31595309786461
```

If we let it run longer, we get a slightly better result.

```Julia-repl
julia> optimizer = HyperND(METISND(); imbalances=100:1:800);

julia> optcode = optimize_code(code, uniformsize(code, 2), optimizer);

julia> contraction_complexity(optcode, uniformsize(optcode, 2)))
Time complexity: 2^125.6119519393784
Space complexity: 2^86.0
Read-write complexity: 2^88.59248638413257
```

This issue is related: https://github.com/TensorBFS/OMEinsumContractionOrders.jl/issues/65

~TODO: tests, documentation~