### PR TITLE
Improve performance of algorithm `HyperND`.

### DIFF
--- a/src/OMEinsumContractionOrders.jl
+++ b/src/OMEinsumContractionOrders.jl
@@ -10,7 +10,7 @@ using TreeWidthSolver
 using TreeWidthSolver.Graphs
 using DataStructures: PriorityQueue, enqueue!, dequeue!, peek, dequeue_pair!
 import CliqueTrees
-using CliqueTrees: cliquetree, residual, EliminationAlgorithm, MMW, BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, MF, BT, SafeRules, KaHyParND, METISND, ND
+using CliqueTrees: cliquetree, residual, EliminationAlgorithm, MMW, BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, MF, BT, SafeRules, KaHyParND, METISND, ND, BestWidth
 
 # interfaces
 export simplify_code, optimize_code, optimize_permute, label_elimination_order, uniformsize

--- a/src/treewidth.jl
+++ b/src/treewidth.jl
@@ -40,14 +40,14 @@ Dict{Char, Int64} with 6 entries:
   'b' => 4
 
 julia> optcode = optimize_code(eincode, size_dict, optimizer)
-ab, ab -> a
-├─ fac, bcf -> ab
-│  ├─ df, acd -> fac
-│  │  ├─ df
-│  │  └─ acd
-│  └─ e, bcef -> bcf
-│     ├─ e
-│     └─ bcef
+ba, ab -> a
+├─ bcf, fac -> ba
+│  ├─ e, bcef -> bcf
+│  │  ├─ e
+│  │  └─ bcef
+│  └─ df, acd -> fac
+│     ├─ df
+│     └─ acd
 └─ ab
 ```
 """


### PR DESCRIPTION
This implementation is faster (~2x) and usually better. I tested it on [these benchmarks](https://github.com/TensorBFS/OMEinsumContractionOrdersBenchmark).

**old implmentation**

```
Running benchmarks with optimizer: HyperND(; imbalances=100:10:800)
julia --project -e "include(\"runner.jl\"); run([HyperND(; imbalances=100:10:800)])"
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/independentset/codes/ksg.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), MMD(0)), 6, 120, 100:10:800)
┌ Info: Contraction complexity: Time complexity: 2^36.52022934116848
│ Space complexity: 2^25.0
└ Read-write complexity: 2^28.545823071935096, time cost: 79.806219875s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/independentset/results/8780387642243926409.json
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/independentset/codes/rg3.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), MMD(0)), 6, 120, 100:10:800)
┌ Info: Contraction complexity: Time complexity: 2^30.58288429439303
│ Space complexity: 2^24.0
└ Read-write complexity: 2^27.833434975539014, time cost: 5.453234458s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/independentset/results/15143769410893384746.json
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/inference/codes/relational_3.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), MMD(0)), 6, 120, 100:10:800)
┌ Info: Contraction complexity: Time complexity: 2^16.936304369223116
│ Space complexity: 2^7.0
└ Read-write complexity: 2^17.468981936049286, time cost: 22.836153375s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/inference/results/13289501071216059811.json
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/nqueens/codes/nqueens_n=28.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), MMD(0)), 6, 120, 100:10:800)
┌ Info: Contraction complexity: Time complexity: 2^126.17125532569021
│ Space complexity: 2^87.0
└ Read-write complexity: 2^89.09395073537529, time cost: 240.201767875s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/nqueens/results/6702432040585739467.json
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/qec/codes/surfacecode_d=21.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), MMD(0)), 6, 120, 100:10:800)
┌ Info: Contraction complexity: Time complexity: 2^54.73220760607484
│ Space complexity: 2^40.0
└ Read-write complexity: 2^44.67860539782252, time cost: 47.914158416s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/qec/results/3510653599773388931.json
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/quantumcircuit/codes/sycamore_53_20_0.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), MMD(0)), 6, 120, 100:10:800)
┌ Info: Contraction complexity: Time complexity: 2^72.9099059682612
│ Space complexity: 2^52.0
└ Read-write complexity: 2^56.760537960513965, time cost: 62.278487292s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/quantumcircuit/results/10986126737694666977.json
```

**new implementation**

```
Running benchmarks with optimizer: HyperND(; imbalances=100:10:800)
julia --project -e "include(\"runner.jl\"); run([HyperND(; imbalances=100:10:800)])"
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/independentset/codes/ksg.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, AMF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), AMF(), MMD(0)), 6, 120, 100:10:800, :space)
┌ Info: Contraction complexity: Time complexity: 2^36.5328250951203
│ Space complexity: 2^25.0
└ Read-write complexity: 2^28.818297716417163, time cost: 40.541503375s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/independentset/results/11936396215309841808.json
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/independentset/codes/rg3.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, AMF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), AMF(), MMD(0)), 6, 120, 100:10:800, :space)
┌ Info: Contraction complexity: Time complexity: 2^30.050491008846258
│ Space complexity: 2^24.0
└ Read-write complexity: 2^27.414379663480673, time cost: 2.805225333s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/independentset/results/18299777983959300145.json
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/inference/codes/relational_3.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, AMF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), AMF(), MMD(0)), 6, 120, 100:10:800, :space)
┌ Info: Contraction complexity: Time complexity: 2^16.936304369223116
│ Space complexity: 2^7.0
└ Read-write complexity: 2^17.468981936049286, time cost: 11.44290025s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/inference/results/16445509644281975210.json
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/nqueens/codes/nqueens_n=28.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, AMF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), AMF(), MMD(0)), 6, 120, 100:10:800, :space)
┌ Info: Contraction complexity: Time complexity: 2^127.32446204618543
│ Space complexity: 2^86.0
└ Read-write complexity: 2^89.25053476030998, time cost: 150.763191375s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/nqueens/results/9858440613651654866.json
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/qec/codes/surfacecode_d=21.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, AMF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), AMF(), MMD(0)), 6, 120, 100:10:800, :space)
┌ Info: Contraction complexity: Time complexity: 2^53.411131484359345
│ Space complexity: 2^40.0
└ Read-write complexity: 2^44.895786162384844, time cost: 24.788094083s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/qec/results/6666662172839304330.json
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/quantumcircuit/codes/sycamore_53_20_0.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, AMF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), AMF(), MMD(0)), 6, 120, 100:10:800, :space)
┌ Info: Contraction complexity: Time complexity: 2^72.25748824756683
│ Space complexity: 2^52.0
└ Read-write complexity: 2^56.94478309709018, time cost: 32.450092s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/quantumcircuit/results/14142135310760582376.json
```

I also added the option to prioritize time over space complexity. Maybe this should be a function `cost(tc::Float64, sc::Float64, rwc::Float64)`?

```
Running benchmarks with optimizer: HyperND(; imbalances=100:10:800, target=:time)
julia --project -e "include(\"runner.jl\"); run([HyperND(; imbalances=100:10:800, target=:time)])"
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/independentset/codes/ksg.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, AMF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), AMF(), MMD(0)), 6, 120, 100:10:800, :time)
┌ Info: Contraction complexity: Time complexity: 2^36.4217798051797
│ Space complexity: 2^27.0
└ Read-write complexity: 2^28.71623600110167, time cost: 40.93783325s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/independentset/results/11936396215309841808.json
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/independentset/codes/rg3.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, AMF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), AMF(), MMD(0)), 6, 120, 100:10:800, :time)
┌ Info: Contraction complexity: Time complexity: 2^29.897951283829485
│ Space complexity: 2^25.0
└ Read-write complexity: 2^28.93895021897721, time cost: 2.886380625s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/independentset/results/18299777983959300145.json
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/inference/codes/relational_3.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, AMF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), AMF(), MMD(0)), 6, 120, 100:10:800, :time)
┌ Info: Contraction complexity: Time complexity: 2^16.936304369223116
│ Space complexity: 2^7.0
└ Read-write complexity: 2^17.468981936049286, time cost: 11.470039708s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/inference/results/16445509644281975210.json
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/nqueens/codes/nqueens_n=28.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, AMF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), AMF(), MMD(0)), 6, 120, 100:10:800, :time)
┌ Info: Contraction complexity: Time complexity: 2^125.70390379950025
│ Space complexity: 2^94.0
└ Read-write complexity: 2^95.01940989829338, time cost: 151.346415416s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/nqueens/results/9858440613651654866.json
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/qec/codes/surfacecode_d=21.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, AMF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), AMF(), MMD(0)), 6, 120, 100:10:800, :time)
┌ Info: Contraction complexity: Time complexity: 2^53.411131484359345
│ Space complexity: 2^40.0
└ Read-write complexity: 2^44.895786162384844, time cost: 24.986439292s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/qec/results/6666662172839304330.json
[ Info: Testing: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/quantumcircuit/codes/sycamore_53_20_0.json with HyperND{KaHyParND{Base.Order.ForwardOrdering}, Tuple{MF, AMF, MMD}}(KaHyParND{Base.Order.ForwardOrdering}(Base.Order.ForwardOrdering(), 1.0), (MF(), AMF(), MMD(0)), 6, 120, 100:10:800, :time)
┌ Info: Contraction complexity: Time complexity: 2^67.82223490180519
│ Space complexity: 2^54.0
└ Read-write complexity: 2^57.58623199355215, time cost: 32.557983833s, saving to: /Users/richardsamuelson/Source/git/OMEinsumContractionOrdersBenchmark/examples/quantumcircuit/results/14142135310760582376.json
```
