### PR TITLE
Path decomposition with the simulation annealing algorithm

### DIFF
--- a/src/Core.jl
+++ b/src/Core.jl
@@ -88,6 +88,26 @@ Abstract type for code slicers.
 """
 abstract type CodeSlicer end
 
+"""
+    AbstractDecompositionType
+
+Abstract type for decomposition types, which includes [`TreeDecomp`](@ref) and [`PathDecomp`](@ref).
+"""
+abstract type AbstractDecompositionType end
+
+"""
+    TreeDecomp <: AbstractDecompositionType
+
+Tree decomposition type.
+"""
+struct TreeDecomp <: AbstractDecompositionType end
+
+"""
+    PathDecomp <: AbstractDecompositionType
+
+Path decomposition type.
+"""
+struct PathDecomp <: AbstractDecompositionType end
 
 """
     ScoreFunction
@@ -170,6 +190,9 @@ function is_binary(code::NestedEinsum)
     isleaf(code) && return true
     length(code.args) == 2 && all(is_binary, code.args)
 end
+# a path decomposition is represented as a contraction tree like
+# a,b,c,d,e -> (((a,b),c),d),e
+is_path_decomposition(ne::NestedEinsum) = isleaf(ne) || length(ne.args) <= 2 && is_path_decomposition(ne.args[1]) && (length(ne.args) == 1 || isleaf(ne.args[2]))
 
 """
     SlicedEinsum{LT,ET<:Union{EinCode{LT},NestedEinsum{LT}}} <: AbstractEinsum
@@ -190,6 +213,7 @@ Base.:(==)(a::SlicedEinsum, b::SlicedEinsum) = a.slicing == b.slicing && a.eins 
 getixsv(se::SlicedEinsum) = getixsv(se.eins)
 getiyv(se::SlicedEinsum) = getiyv(se.eins)
 is_binary(code::SlicedEinsum) = is_binary(code.eins)
+is_path_decomposition(ne::SlicedEinsum) = is_path_decomposition(ne.eins)
 
 # Better printing
 struct LeafString

--- a/src/OMEinsumContractionOrders.jl
+++ b/src/OMEinsumContractionOrders.jl
@@ -16,10 +16,13 @@ using CliqueTrees: cliquetree, residual, EliminationAlgorithm, MMW, BFS, MCS, Le
 export simplify_code, optimize_code, slice_code, optimize_permute, label_elimination_order, uniformsize, ScoreFunction
 
 # optimizers
-export CodeOptimizer, KaHyParBipartite, GreedyMethod, TreeSA, SABipartite, Treewidth, ExactTreewidth, HyperND
+export CodeOptimizer, KaHyParBipartite, GreedyMethod, TreeSA, SABipartite, Treewidth, ExactTreewidth, HyperND, PathSA
 
 # slicers
 export CodeSlicer, TreeSASlicer
+
+# decomposition types
+export AbstractDecompositionType, TreeDecomp, PathDecomp
 
 # preprocessing
 export CodeSimplifier, MergeGreedy, MergeVectors

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -71,10 +71,11 @@ Slice the einsum contraction code to reduce the space complexity, returns a `Sli
 # Arguments
 - `code` is a `NestedEinsum` instance.
 - `size_dict` is a dictionary of "edge label=>edge size" that contains the size information, one can use `uniformsize(eincode, 2)` to create a uniform size.
-- `slicer` is a `CodeSlicer` instance, currently only `TreeSASlicer` is supported.
+- `slicer` is a `CodeSlicer` instance, currently only [`TreeSASlicer`](@ref) is supported.
 """
 function slice_code(code::NestedEinsum, size_dict, slicer::TreeSASlicer)
     slice_tree(code, size_dict; score=slicer.score, βs=slicer.βs,
         ntrials=slicer.ntrials, niters=slicer.niters,
-        optimization_ratio=slicer.optimization_ratio)
+        optimization_ratio=slicer.optimization_ratio,
+        decomposition_type=slicer.decomposition_type)
 end

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -56,7 +56,8 @@ end
 function _optimize_code(code, size_dict, optimizer::TreeSA)
     optimize_tree(code, size_dict; βs=optimizer.βs,
         ntrials=optimizer.ntrials, niters=optimizer.niters,
-        initializer=optimizer.initializer, score=optimizer.score)
+        initializer=optimizer.initializer, score=optimizer.score,
+        decomposition_type=optimizer.decomposition_type)
 end
 function _optimize_code(code, size_dict, optimizer::HyperND)
     optimize_hyper_nd(optimizer, code, size_dict)

--- a/src/treesa.jl
+++ b/src/treesa.jl
@@ -50,13 +50,13 @@ _equal(t1::Vector, t2::Vector) = Set(t1) == Set(t2)
 
 
 ############# random expression tree ###############
-function random_exprtree(code::EinCode)
+function random_exprtree(code::EinCode, decomposition_type::AbstractDecompositionType)
     ixs, iy = getixsv(code), getiyv(code)
     labels = _label_dict(ixs, iy)
-    return random_exprtree([Int[labels[l] for l in ix] for ix in ixs], Int[labels[l] for l in iy], length(labels))
+    return random_exprtree([Int[labels[l] for l in ix] for ix in ixs], Int[labels[l] for l in iy], length(labels), decomposition_type)
 end
 
-function random_exprtree(ixs::Vector{Vector{Int}}, iy::Vector{Int}, nedge::Int)
+function random_exprtree(ixs::Vector{Vector{Int}}, iy::Vector{Int}, nedge::Int, decomposition_type::AbstractDecompositionType)
     outercount = zeros(Int, nedge)
     allcount = zeros(Int, nedge)
     for l in iy
@@ -68,17 +68,21 @@ function random_exprtree(ixs::Vector{Vector{Int}}, iy::Vector{Int}, nedge::Int)
             allcount[l] += 1
         end
     end
-    _random_exprtree(ixs, collect(1:length(ixs)), outercount, allcount)
+    _random_exprtree(ixs, collect(1:length(ixs)), outercount, allcount, decomposition_type)
 end
-function _random_exprtree(ixs::Vector{Vector{Int}}, xindices, outercount::Vector{Int}, allcount::Vector{Int})
+function _random_exprtree(ixs::Vector{Vector{Int}}, xindices, outercount::Vector{Int}, allcount::Vector{Int}, decomposition_type::AbstractDecompositionType)
     n = length(ixs)
     if n == 1
         return ExprTree(ExprInfo(ixs[1], xindices[1]))
     end
-    mask = rand(Bool, n)
-    if all(mask) || !any(mask)  # prevent invalid partition
-        i = rand(1:n)
-        mask[i] = ~(mask[i])
+    if decomposition_type == TreeDecomp()
+        mask = rand(Bool, n)
+        if all(mask) || !any(mask)  # prevent invalid partition
+            i = rand(1:n)
+            mask[i] = ~(mask[i])
+        end
+    else
+        mask = fill(true, n); mask[end] = false  # for path decomposition, the last nodes belongs to the right tree
     end
     info = ExprInfo(Int[i for i=1:length(outercount) if outercount[i]!=allcount[i] && outercount[i]!=0])
     outercount1, outercount2 = copy(outercount), copy(outercount)
@@ -88,7 +92,7 @@ function _random_exprtree(ixs::Vector{Vector{Int}}, xindices, outercount::Vector
             counter[l] += 1
         end
     end
-    return ExprTree(_random_exprtree(ixs[mask], xindices[mask], outercount1, allcount), _random_exprtree(ixs[(!).(mask)], xindices[(!).(mask)], outercount2, allcount), info)
+    return ExprTree(_random_exprtree(ixs[mask], xindices[mask], outercount1, allcount, decomposition_type), _random_exprtree(ixs[(!).(mask)], xindices[(!).(mask)], outercount2, allcount, decomposition_type), info)
 end
 
 
@@ -104,8 +108,8 @@ end
 
 ##################### The main program ##############################
 """
-    TreeSA{IT} <: CodeOptimizer
-    TreeSA(; βs=collect(0.01:0.05:15), ntrials=10, niters=50, initializer=:greedy, score=ScoreFunction())
+    TreeSA{IT, DT} <: CodeOptimizer
+    TreeSA(; βs=collect(0.01:0.05:15), ntrials=10, niters=50, initializer=:greedy, score=ScoreFunction(), decomposition_type=TreeDeomp())
 
 Optimize the einsum contraction pattern using the simulated annealing on tensor expression tree.
 
@@ -113,6 +117,7 @@ Optimize the einsum contraction pattern using the simulated annealing on tensor 
 - `ntrials`, `βs` and `niters` are annealing parameters, doing `ntrials` indepedent annealings, each has inverse tempteratures specified by `βs`, in each temperature, do `niters` updates of the tree.
 - `initializer` specifies how to determine the initial configuration, it can be `:greedy`, `:random` or `:specified`. If the initializer is `:specified`, the input `code` should be a `NestedEinsum` object.
 - `score` specifies the score function to evaluate the quality of the contraction tree, it is a function of time complexity, space complexity and read-write complexity.
+- `decomposition_type` specifies the type of decomposition to use, it can be `TreeDeomp` or `PathDecomp`.
 
 # References
 - [Recursive Multi-Tensor Contraction for XEB Verification of Quantum Circuits](https://arxiv.org/abs/2108.05665)
@@ -121,12 +126,26 @@ Optimize the einsum contraction pattern using the simulated annealing on tensor 
 - `nslices` is removed, since the slicing part is now separated from the optimization part, see `slice_code` function and `TreeSASlicer`.
 - `greedy_method` is removed. If you want to have detailed control of the initializer, please pre-optimize the code with another method and then use `:specified` to initialize the tree.
 """
-Base.@kwdef struct TreeSA{IT} <: CodeOptimizer
+Base.@kwdef struct TreeSA{IT, DT <: AbstractDecompositionType} <: CodeOptimizer
     βs::IT = 0.01:0.05:15
     ntrials::Int = 10
     niters::Int = 50
     initializer::Symbol = :greedy
     score::ScoreFunction = ScoreFunction()
+    decomposition_type::DT = TreeDecomp()
+end
+
+const PathSA = TreeSA{<:Any, PathDecomp}
+"""
+    PathSA(; βs=0.01:0.05:15, ntrials=10, niters=50, score=ScoreFunction())
+
+Optimize the einsum contraction pattern using the simulated annealing on tensor expression tree, with path decomposition.
+
+# Fields
+- `βs`, `ntrials`, `niters` and `score` are the same as in [`TreeSA`](@ref).
+"""
+function PathSA(; βs=0.01:0.05:15, ntrials=10, niters=50, score=ScoreFunction())
+    TreeSA(; βs, ntrials, niters, score, initializer=:random, decomposition_type=PathDecomp())
 end
 
 # this is the main function
@@ -136,7 +155,7 @@ end
 Optimize the einsum contraction pattern specified by `code`, and edge sizes specified by `size_dict`.
 Check the docstring of [`TreeSA`](@ref) for detailed explaination of other input arguments.
 """
-function optimize_tree(code::AbstractEinsum, size_dict::Dict{LT,Int}; βs, ntrials, niters, initializer, score) where LT
+function optimize_tree(code::AbstractEinsum, size_dict::Dict{LT,Int}; βs, ntrials, niters, initializer, score, decomposition_type) where LT
     # get input labels (`getixsv`) and output labels (`getiyv`) in the einsum code.
     ixs, iy = getixsv(code), getiyv(code)
     ninputs = length(ixs)  # number of input tensors
@@ -150,7 +169,7 @@ function optimize_tree(code::AbstractEinsum, size_dict::Dict{LT,Int}; βs, ntria
     log2_sizes = [log2.(size_dict[inverse_map[i]]) for i=1:length(labels)]   # use `log2` sizes in computing time
 
     if ntrials <= 0  # no optimization at all, then 1). initialize an expression tree and 2). convert back to nested einsum.
-        best_tree = _initializetree(code, size_dict, initializer)
+        best_tree = _initializetree(code, size_dict, initializer, decomposition_type)
         return NestedEinsum(best_tree, inverse_map)
     end
 
@@ -160,10 +179,10 @@ function optimize_tree(code::AbstractEinsum, size_dict::Dict{LT,Int}; βs, ntria
     @threads for t = 1:ntrials  # multi-threading on different trials, use `JULIA_NUM_THREADS=5 julia xxx.jl` for setting number of threads.
 
         # 1). random/greedy initialize a contraction tree.
-        tree = _initializetree(code, size_dict, initializer)
+        tree = _initializetree(code, size_dict, initializer, decomposition_type)
 
         # 2). optimize the `tree` in a inplace manner.
-        optimize_tree_sa!(tree, log2_sizes; βs, niters, score)
+        optimize_tree_sa!(tree, log2_sizes; βs, niters, score, decomposition_type)
 
         # 3). evaluate time-space-readwrite complexities.
         tc, sc, rw = tree_timespace_complexity(tree, log2_sizes)
@@ -179,12 +198,17 @@ function optimize_tree(code::AbstractEinsum, size_dict::Dict{LT,Int}; βs, ntria
 end
 
 # initialize a contraction tree
-function _initializetree(code, size_dict, method)
+function _initializetree(code, size_dict, method, decomposition_type)
+    # for path decomposition, only random initialization is supported
+    if decomposition_type == PathDecomp()
+        method != :random && warn("only random initialization is supported for path decomposition, got: $method")  # only random initialization is supported for path decomposition
+        return random_exprtree(code, decomposition_type)
+    end
     if method == :greedy
         labels = _label_dict(code)  # label to int
         return _exprtree(optimize_greedy(code, size_dict; α = 0.0, temperature = 0.0), labels)
     elseif method == :random
-        return random_exprtree(code)
+        return random_exprtree(code, decomposition_type)
     elseif method == :specified
         labels = _label_dict(code)  # label to int
         return _exprtree(code, labels)
@@ -194,7 +218,7 @@ function _initializetree(code, size_dict, method)
 end
 
 # use simulated annealing to optimize a contraction tree
-function optimize_tree_sa!(tree::ExprTree, log2_sizes; βs, niters, score)
+function optimize_tree_sa!(tree::ExprTree, log2_sizes; βs, niters, score, decomposition_type)
     log2rw_weight = log2(score.rw_weight)
 
     tc, sc, rw = tree_timespace_complexity(tree, log2_sizes)
@@ -202,7 +226,7 @@ function optimize_tree_sa!(tree::ExprTree, log2_sizes; βs, niters, score)
     
     for β in βs
         for _ = 1:niters
-            optimize_subtree!(tree, β, log2_sizes, score.sc_target, score.sc_weight, log2rw_weight)  # single sweep
+            optimize_subtree!(tree, β, log2_sizes, score.sc_target, score.sc_weight, log2rw_weight, decomposition_type)  # single sweep
         end
     end
 
@@ -242,10 +266,10 @@ end
 end
 
 # optimize a contraction tree recursively
-function optimize_subtree!(tree, β, log2_sizes, sc_target, sc_weight, log2rw_weight)
+function optimize_subtree!(tree, β, log2_sizes, sc_target, sc_weight, log2rw_weight, decomposition_type)
     # find appliable local rules, at most 4 rules can be applied.
     # Sometimes, not all rules are applicable because either left or right sibling do not have siblings.
-    rst = ruleset(tree)
+    rst = ruleset(decomposition_type, tree)
     if !isempty(rst)
         # propose a random update rule, TODO: can we have a better selector?
         rule = rand(rst)
@@ -261,7 +285,7 @@ function optimize_subtree!(tree, β, log2_sizes, sc_target, sc_weight, log2rw_we
             update_tree!(tree, rule, subout)
         end
         for subtree in siblings(tree)  # RECURSE
-            optimize_subtree!(subtree, β, log2_sizes, sc_target, sc_weight, log2rw_weight)
+            optimize_subtree!(subtree, β, log2_sizes, sc_target, sc_weight, log2rw_weight, decomposition_type)
         end
     end
 end
@@ -270,7 +294,7 @@ end
 _sc(tree, rule, log2_sizes) = max(__sc(tree, log2_sizes), __sc((rule == 1 || rule == 2) ? tree.left : tree.right, log2_sizes))
 __sc(tree, log2_sizes) = length(labels(tree))==0 ? 0.0 : sum(l->log2_sizes[l], labels(tree)) # space complexity of current node
 
-@inline function ruleset(tree::ExprTree)
+@inline function ruleset(::TreeDecomp, tree::ExprTree)
     if isleaf(tree) || (isleaf(tree.left) && isleaf(tree.right))
         return 1:0
     elseif isleaf(tree.right)
@@ -282,6 +306,17 @@ __sc(tree, log2_sizes) = length(labels(tree))==0 ? 0.0 : sum(l->log2_sizes[l], l
     end
 end
 
+@inline function ruleset(::PathDecomp, tree::ExprTree)
+    @assert isleaf(tree) || isleaf(tree.right)  # for path decomposition, the right tree must be a leaf
+    if isleaf(tree)
+        return 1:0
+    elseif isleaf(tree.left)  # SWAP on leaves
+        return 5:5
+    else
+        return 1:1
+    end
+end
+
 function tcsc_diff(tree::ExprTree, rule, log2_sizes, optimize_rw)
     if rule == 1 # (a,b), c -> (a,c),b
         return abcacb(labels(tree.left.left), labels(tree.left.right), labels(tree.left), labels(tree.right), labels(tree), log2_sizes, optimize_rw)
@@ -289,8 +324,13 @@ function tcsc_diff(tree::ExprTree, rule, log2_sizes, optimize_rw)
         return abcacb(labels(tree.left.right), labels(tree.left.left), labels(tree.left), labels(tree.right), labels(tree), log2_sizes, optimize_rw)
     elseif rule == 3 # a,(b,c) -> b,(a,c)
         return abcacb(labels(tree.right.right), labels(tree.right.left), labels(tree.right), labels(tree.left), labels(tree), log2_sizes, optimize_rw)
-    else  # a,(b,c) -> c,(b,a)
+    elseif rule == 4 # a,(b,c) -> c,(b,a)
         return abcacb(labels(tree.right.left), labels(tree.right.right), labels(tree.right), labels(tree.left), labels(tree), log2_sizes, optimize_rw)
+    elseif rule == 5 # a,b -> b,a
+        tc0, sc0, rw0 = tcscrw(labels(tree.left), labels(tree.right), labels(tree), log2_sizes, optimize_rw)
+        return tc0, tc0, zero(sc0), rw0, rw0, labels(tree)
+    else
+        error("Rule $rule is not defined!")
     end
 end
 
@@ -336,11 +376,17 @@ function update_tree!(tree::ExprTree, rule::Int, subout)
         tree.left = b
         tree.right.left = a
         tree.right.info = ExprInfo(subout)
-    else  # a,(b,c) -> c,(b,a)
+    elseif rule == 4 # a,(b,c) -> c,(b,a)
         a, c = tree.left, tree.right.right
         tree.left = c
         tree.right.right = a
         tree.right.info = ExprInfo(subout)
+    elseif rule == 5 # a,b -> b,a
+        a, b = tree.left, tree.right
+        tree.left = b
+        tree.right = a
+    else
+        error("Rule $rule is not defined!")
     end
     return tree
 end

--- a/test/interfaces.jl
+++ b/test/interfaces.jl
@@ -136,3 +136,14 @@ if isdefined(Base, :get_extension)
         @test optcode(a, b, c) ≈ code(a, b, c)
     end
 end
+
+@testset "path decomposition" begin
+    code = ein"i,j->"
+    optcode = optimize_code(code, Dict('i'=>1024, 'j'=>1024), PathSA())
+    @test OMEinsumContractionOrders.is_path_decomposition(OMEinsum.rawcode(optcode))
+    code = ein"lm,jk,ij,kl->"
+    optcode = optimize_code(code, Dict('i'=>1024, 'j'=>1024, 'k'=>1024, 'l'=>1024, 'm'=>1024), PathSA())
+    @test OMEinsumContractionOrders.is_path_decomposition(OMEinsum.rawcode(optcode))
+    cc = contraction_complexity(optcode, uniformsize(code, 1024))
+    @test cc.sc ≈ 10
+end

--- a/test/treesa.jl
+++ b/test/treesa.jl
@@ -26,9 +26,9 @@ end
         return OMEinsumContractionOrders.EinCode([ixs..., [[i] for i in Graphs.vertices(g)]...], Int[])
     end
     Random.seed!(2)
-    tree = random_exprtree([[1,2,5], [2,3], [2,4]], [5], 5)
+    tree = random_exprtree([[1,2,5], [2,3], [2,4]], [5], 5, TreeDecomp())
     @test tree isa ExprTree
-    tree2 = random_exprtree(OMEinsumContractionOrders.EinCode([[1,2,5], [2,3], [2,4]], [5]))
+    tree2 = random_exprtree(OMEinsumContractionOrders.EinCode([[1,2,5], [2,3], [2,4]], [5]), TreeDecomp())
     @test tree isa ExprTree
     code = random_regular_eincode(20, 3)
     optcode = optimize_greedy(code, uniformsize(code, 2); α=0.0, temperature=0.0)
@@ -46,10 +46,14 @@ end
     t2 = ExprTree(ExprTree(LeafNode(1, [2,3]), LeafNode(2, [1,4]), ExprInfo([1,2,3])), LeafNode(3,[1,2]), ExprInfo([2]))
     t3 = ExprTree(LeafNode(1,[2,3]), LeafNode(2, [1,2]), ExprInfo([2]))
     t4 = ExprTree(ExprTree(LeafNode(1, [2,3]), LeafNode(2, [1,4]), ExprInfo([1,2])), ExprTree(LeafNode(4,[5,1]), LeafNode(3,[1]), ExprInfo([1])), ExprInfo([2]))
-    @test ruleset(t1) == 3:4
-    @test ruleset(t2) == 1:2
-    @test ruleset(t3) == 1:0
-    @test ruleset(t4) == 1:4
+    @test ruleset(TreeDecomp(), t1) == 3:4
+    @test ruleset(TreeDecomp(), t2) == 1:2
+    @test ruleset(TreeDecomp(), t3) == 1:0
+    @test ruleset(TreeDecomp(), t4) == 1:4
+    @test_throws AssertionError ruleset(PathDecomp(), t1)
+    @test ruleset(PathDecomp(), t2) == 1:1
+    @test ruleset(PathDecomp(), t3) == 5:5
+    @test_throws AssertionError ruleset(PathDecomp(), t4)
     log2_sizes = ones(5)
     _tcsc(t, l) = tcscrw(labels(t.left), labels(t.right), labels(t), l, true)
     @test all(_tcsc(t1, log2_sizes) .≈ (2.0, 1.0, log2(10)))
@@ -88,7 +92,7 @@ end
     tc0_, sc0_ = cc0.tc, cc0.sc
     @test tc0 ≈ tc0_ && sc0 ≈ sc0_
     opt_tree = copy(tree)
-    optimize_subtree!(opt_tree, 100.0, log2_sizes, 5, 2.0, 1.0)
+    optimize_subtree!(opt_tree, 100.0, log2_sizes, 5, 2.0, 1.0, TreeDecomp())
     tc1, sc1, rw0 = tree_timespace_complexity(opt_tree, log2_sizes)
     @test sc1 < sc0 || (sc1 == sc0 && tc1 < tc0)
 end
@@ -108,7 +112,7 @@ end
     tree = ExprTree(optcode)
     tc0, sc0, rw0 = tree_timespace_complexity(tree, log2_sizes)
     opttree = copy(tree)
-    optimize_tree_sa!(opttree, log2_sizes; βs=0.1:0.1:10.0, niters=100, score=ScoreFunction(sc_target=sc0-2.0))
+    optimize_tree_sa!(opttree, log2_sizes; βs=0.1:0.1:10.0, niters=100, score=ScoreFunction(sc_target=sc0-2.0), decomposition_type=TreeDecomp())
     tc1, sc1, rw1 = tree_timespace_complexity(opttree, log2_sizes)
     @test sc1 < sc0 || (sc1 == sc0 && tc1 < tc0)
 end
@@ -126,15 +130,15 @@ end
     cc = contraction_complexity(res, uniformsize(code, 2))
     tc, sc = cc.tc, cc.sc
 
-    @test optimize_tree(res, uniformsize(code, 2); βs=0.1:0.05:20.0, ntrials=0, niters=10, initializer=:greedy, score=ScoreFunction(sc_target=32)) isa OMEinsumContractionOrders.NestedEinsum
-    optcode = optimize_tree(res, uniformsize(code, 2); βs=0.1:0.05:20.0, ntrials=2, niters=10, initializer=:greedy, score=ScoreFunction(sc_target=32))
+    @test optimize_tree(res, uniformsize(code, 2); βs=0.1:0.05:20.0, ntrials=0, niters=10, initializer=:greedy, score=ScoreFunction(sc_target=32), decomposition_type=TreeDecomp()) isa OMEinsumContractionOrders.NestedEinsum
+    optcode = optimize_tree(res, uniformsize(code, 2); βs=0.1:0.05:20.0, ntrials=2, niters=10, initializer=:greedy, score=ScoreFunction(sc_target=32), decomposition_type=TreeDecomp())
     cc = contraction_complexity(optcode, uniformsize(code, 2))
     @test cc.sc <= 32
 
     # contraction test
     code = random_regular_eincode(50, 3)
     codek = optimize_greedy(code, uniformsize(code, 2); α=0.0, temperature=0.0)
-    codeg = optimize_tree(code, uniformsize(code, 2); initializer=:random, βs=0.1:0.05:20.0, ntrials=2, niters=10, score=ScoreFunction(sc_target=12))
+    codeg = optimize_tree(code, uniformsize(code, 2); initializer=:random, βs=0.1:0.05:20.0, ntrials=2, niters=10, score=ScoreFunction(sc_target=12), decomposition_type=TreeDecomp())
     cc = contraction_complexity(codek, uniformsize(code, 2))
     @test cc.sc <= 12
     xs = [[2*randn(2, 2) for i=1:75]..., [randn(2) for i=1:50]...]
@@ -145,7 +149,7 @@ end
     # contraction test
     code = random_regular_eincode(50, 3)
     codek = optimize_greedy(code, uniformsize(code, 2); α=0.0, temperature=0.0)
-    codeg = optimize_tree(codek, uniformsize(code, 2); initializer=:specified, βs=0.1:0.05:20.0, ntrials=2, niters=10, score=ScoreFunction(sc_target=12))
+    codeg = optimize_tree(codek, uniformsize(code, 2); initializer=:specified, βs=0.1:0.05:20.0, ntrials=2, niters=10, score=ScoreFunction(sc_target=12), decomposition_type=TreeDecomp())
     cc = contraction_complexity(codek, uniformsize(code, 2))
     @test cc.sc <= 12
     xs = [[2*randn(2, 2) for i=1:75]..., [randn(2) for i=1:50]...]

--- a/test/treesaslicer.jl
+++ b/test/treesaslicer.jl
@@ -18,10 +18,10 @@ using KaHyPar
     code = random_regular_eincode(100, 3)
 
     for code0 in [optimize_greedy(code, uniformsize(code, 2); α=0.0, temperature=0.0),
-            optimize_tree(code, uniformsize(code, 2); initializer=:greedy, βs=0.1:0.05:20.0, ntrials=2, niters=10, score=ScoreFunction(sc_target=10)),
+            optimize_tree(code, uniformsize(code, 2); initializer=:greedy, βs=0.1:0.05:20.0, ntrials=2, niters=10, score=ScoreFunction(sc_target=10), decomposition_type=TreeDecomp()),
             optimize_hyper_nd(HyperND(), code, uniformsize(code, 2))]
 
-        codet = slice_tree(code0, uniformsize(code, 2); score=ScoreFunction(sc_target=10))
+        codet = slice_tree(code0, uniformsize(code, 2); score=ScoreFunction(sc_target=10), decomposition_type=TreeDecomp())
         @test codet isa SlicedEinsum
 
         cc0 = contraction_complexity(code0, uniformsize(code, 2))
@@ -42,9 +42,9 @@ using KaHyPar
     code = OMEinsumContractionOrders.EinCode(random_regular_eincode(100, 3).ixs, [3,81,2])
 
     for code0 in [optimize_greedy(code, uniformsize(code, 2); α=0.0, temperature=0.0),
-            optimize_tree(code, uniformsize(code, 2); initializer=:greedy, βs=0.1:0.05:20.0, ntrials=2, niters=10, score=ScoreFunction(sc_target=10)),
+            optimize_tree(code, uniformsize(code, 2); initializer=:greedy, βs=0.1:0.05:20.0, ntrials=2, niters=10, score=ScoreFunction(sc_target=10), decomposition_type=TreeDecomp()),
             optimize_hyper_nd(HyperND(), code, uniformsize(code, 2))]
-        codet = slice_tree(code0, uniformsize(code, 2); score=ScoreFunction(sc_target=10), ntrials = 10)
+        codet = slice_tree(code0, uniformsize(code, 2); score=ScoreFunction(sc_target=10), ntrials = 10, decomposition_type=TreeDecomp())
         @test codet isa SlicedEinsum
 
         cc0 = contraction_complexity(code0, uniformsize(code, 2))
@@ -63,10 +63,10 @@ using KaHyPar
     Random.seed!(2)
     code = OMEinsumContractionOrders.EinCode(random_regular_eincode(100, 3).ixs, [3,10,2])
     for code0 in [optimize_greedy(code, uniformsize(code, 2); α=0.0, temperature=0.0),
-            optimize_tree(code, uniformsize(code, 2); initializer=:greedy, βs=0.1:0.05:20.0, ntrials=2, niters=10, score=ScoreFunction(sc_target=10)),
+            optimize_tree(code, uniformsize(code, 2); initializer=:greedy, βs=0.1:0.05:20.0, ntrials=2, niters=10, score=ScoreFunction(sc_target=10), decomposition_type=TreeDecomp()),
             optimize_hyper_nd(HyperND(), code, uniformsize(code, 2))]
-        code1 = slice_tree(code0, uniformsize(code, 2); score=ScoreFunction(sc_target=10), fixed_slices=[10, 89, 26, 3, 51])
-        code2 = slice_tree(code0, uniformsize(code, 2); score=ScoreFunction(sc_target=10), fixed_slices=[10, 89])
+        code1 = slice_tree(code0, uniformsize(code, 2); score=ScoreFunction(sc_target=10), fixed_slices=[10, 89, 26, 3, 51], decomposition_type=TreeDecomp())
+        code2 = slice_tree(code0, uniformsize(code, 2); score=ScoreFunction(sc_target=10), fixed_slices=[10, 89], decomposition_type=TreeDecomp())
 
         @test length(code1.slicing) >= 5 && Set([10, 89, 26, 3, 51]) ⊆ Set(code1.slicing)
         @test length(code2.slicing) >= 2 && Set([10, 89]) ⊆ Set(code2.slicing)
@@ -87,8 +87,8 @@ using KaHyPar
         return OMEinsumContractionOrders.EinCode([ixs..., [['0'+i] for i in Graphs.vertices(g)]...], Char[])
     end
     code = OMEinsumContractionOrders.EinCode(random_regular_eincode_char(20, 3).ixs, ['3','8','2'])
-    code0 = optimize_tree(code, uniformsize(code, 2); initializer=:greedy, βs=0.1:0.05:20.0, ntrials=2, niters=10, score=ScoreFunction(sc_target=10))
-    code1 = slice_tree(code0, uniformsize(code, 2); score=ScoreFunction(sc_target=5), fixed_slices=['7'])
+    code0 = optimize_tree(code, uniformsize(code, 2); initializer=:greedy, βs=0.1:0.05:20.0, ntrials=2, niters=10, score=ScoreFunction(sc_target=10), decomposition_type=TreeDecomp())
+    code1 = slice_tree(code0, uniformsize(code, 2); score=ScoreFunction(sc_target=5), fixed_slices=['7'], decomposition_type=TreeDecomp())
     @test eltype(code1.eins.eins.iy) == Char
 
     xs = [[2*randn(2, 2) for i=1:30]..., [randn(2) for i=1:20]...]


### PR DESCRIPTION
I extended the `TreeSA` algorithm a bit to support path decomposition finding.
```julia
julia> using OMEinsum

julia> code = ein"lm,jk,ij,kl->"
lm, jk, ij, kl -> 

julia> optcode = optimize_code(code, uniformsize(code, 2), PathSA())
l, lm -> 
├─ k, kl -> l
│  ├─ jk, ij -> k
│  │  ├─ jk
│  │  └─ ij
│  └─ kl
└─ lm
```

The resulting order is always in the form `((((a, b), c), d), ...)`, i.e. the right sibling is always the leaf.

@fliingelephant This algorithm can be used in finding the best ordering of sites in MPS. It can be much faster than the branching algorithm implemented in the UnitDiskMapping package.