### PR TITLE
Re-implement optimizer Treewidth

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,9 +20,6 @@ LuxorGraphPlot = "1f49bdf2-22a7-4bc4-978b-948dc219fbbc"
 KaHyParExt = ["KaHyPar"]
 LuxorTensorPlot = ["LuxorGraphPlot"]
 
-[sources]
-CliqueTrees = {path = "../CliqueTrees.jl"}
-
 [compat]
 AbstractTrees = "0.3, 0.4"
 Aqua = "0.8"

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ LuxorTensorPlot = ["LuxorGraphPlot"]
 [compat]
 AbstractTrees = "0.3, 0.4"
 Aqua = "0.8"
-CliqueTrees = "1.12"
+CliqueTrees = "1.12.1"
 DataStructures = "0.18"
 Documenter = "1.10.1"
 Graphs = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -20,10 +20,13 @@ LuxorGraphPlot = "1f49bdf2-22a7-4bc4-978b-948dc219fbbc"
 KaHyParExt = ["KaHyPar"]
 LuxorTensorPlot = ["LuxorGraphPlot"]
 
+[sources]
+CliqueTrees = {path = "../CliqueTrees.jl"}
+
 [compat]
 AbstractTrees = "0.3, 0.4"
 Aqua = "0.8"
-CliqueTrees = "1.5.0"
+CliqueTrees = "1.12"
 DataStructures = "0.18"
 Documenter = "1.10.1"
 Graphs = "1"

--- a/src/OMEinsumContractionOrders.jl
+++ b/src/OMEinsumContractionOrders.jl
@@ -3,14 +3,14 @@ module OMEinsumContractionOrders
 using JSON
 using SparseArrays
 using StatsBase
-using Base: RefValue
+using Base: RefValue, oneto
 using Base.Threads
 using AbstractTrees
 using TreeWidthSolver
 using TreeWidthSolver.Graphs
 using DataStructures: PriorityQueue, enqueue!, dequeue!, peek, dequeue_pair!
 import CliqueTrees
-using CliqueTrees: cliquetree, residual, EliminationAlgorithm, MMW, BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, MF, BT, SafeRules, KaHyParND, METISND, ND, BestWidth
+using CliqueTrees: cliquetree, cliquetree!, separator, residual, EliminationAlgorithm, MMW, BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, MF, BT, SafeRules, KaHyParND, METISND, ND, BestWidth, ConnectedComponents
 
 # interfaces
 export simplify_code, optimize_code, slice_code, optimize_permute, label_elimination_order, uniformsize, ScoreFunction

--- a/src/OMEinsumContractionOrders.jl
+++ b/src/OMEinsumContractionOrders.jl
@@ -3,14 +3,14 @@ module OMEinsumContractionOrders
 using JSON
 using SparseArrays
 using StatsBase
-using Base: RefValue, oneto
+using Base: RefValue
 using Base.Threads
 using AbstractTrees
 using TreeWidthSolver
 using TreeWidthSolver.Graphs
 using DataStructures: PriorityQueue, enqueue!, dequeue!, peek, dequeue_pair!
 import CliqueTrees
-using CliqueTrees: cliquetree, cliquetree!, separator, residual, EliminationAlgorithm, MMW, BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, MF, BT, SafeRules, KaHyParND, METISND, ND, BestWidth, ConnectedComponents
+using CliqueTrees: cliquetree, cliquetree!, separator, residual, CliqueTree, EliminationAlgorithm, MMW, BFS, MCS, LexBFS, RCMMD, RCMGL, MCSM, LexM, AMF, MF, MMD, MF, BT, SafeRules, KaHyParND, METISND, ND, BestWidth, ConnectedComponents
 
 # interfaces
 export simplify_code, optimize_code, slice_code, optimize_permute, label_elimination_order, uniformsize, ScoreFunction

--- a/src/hypernd.jl
+++ b/src/hypernd.jl
@@ -4,6 +4,7 @@
         algs = (MF(), AMF(), MMD()),
         level = 6,
         width = 120,
+        scale = 100,
         imbalances = 130:130,
         score = ScoreFunction(),
     )
@@ -11,7 +12,11 @@
 Nested-dissection based optimizer. Recursively partitions a tensor network, then calls a
 greedy algorithm on the leaves. The optimizer is run a number of times: once for each greedy
 algorithm in `algs` and each imbalance value in `imbalances`. The recursion depth is controlled by
-the parameters `level` and `width`.
+the parameters `level` and `width`. The parameter `scale` controls discretization of the index weights:
+
+    weight(i) := scale * log2(dim(i))
+
+where dim(i) is the dimension of the index i.
 
 The line graph is partitioned using the algorithm `dis`. OMEinsumContractionOrders currently supports two partitioning
 algorithms, both of which require importing an external library.

--- a/src/hypernd.jl
+++ b/src/hypernd.jl
@@ -38,6 +38,7 @@ The optimizer is implemented using the tree decomposition library
     algs::A = (MF(), AMF(), MMD())
     level::Int = 6
     width::Int = 120
+    scale::Int = 100
     imbalances::StepRange{Int, Int} = 130:1:130
     score::ScoreFunction = ScoreFunction()
 end
@@ -47,6 +48,7 @@ function optimize_hyper_nd(optimizer::HyperND, code, size_dict)
     algs = optimizer.algs
     level = optimizer.level
     width = optimizer.width
+    scale = optimizer.scale
     imbalances = optimizer.imbalances
     score = optimizer.score
 
@@ -54,7 +56,7 @@ function optimize_hyper_nd(optimizer::HyperND, code, size_dict)
     local mincode
 
     for imbalance in imbalances
-        curalg = SafeRules(ND(BestWidth(algs), dis; level, width, imbalance))
+        curalg = SafeRules(ND(BestWidth(algs), dis; level, width, scale, imbalance))
         curoptimizer = Treewidth(; alg=curalg)
         curcode = _optimize_code(code, size_dict, curoptimizer)
         curtc, cursc, currw = __timespacereadwrite_complexity(curcode, size_dict)

--- a/src/hypernd.jl
+++ b/src/hypernd.jl
@@ -37,9 +37,9 @@ The optimizer is implemented using the tree decomposition library
     dis::D = KaHyParND()
     algs::A = (MF(), AMF(), MMD())
     level::Int = 6
-    width::Int = 120
+    width::Int = 50
     scale::Int = 100
-    imbalances::StepRange{Int, Int} = 130:1:130
+    imbalances::StepRange{Int, Int} = 100:10:800
     score::ScoreFunction = ScoreFunction()
 end
 

--- a/src/treewidth.jl
+++ b/src/treewidth.jl
@@ -166,14 +166,6 @@ function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:Abst
     permute!(el, perm)
     permute!(ve, oneto(n), perm)
 
-    # the vector `roots` maps each vertex to the root node
-    # of its subtree
-    roots = Vector{Int}(undef, m)
-
-    for (b, bag) in enumerate(tree), e in residual(bag)
-        roots[e] = b
-    end
-
     # dynamic programming
     stack = NestedEinsum{L}[]
 

--- a/src/treewidth.jl
+++ b/src/treewidth.jl
@@ -6,13 +6,6 @@ Tree width based solver. The solvers are implemented in [CliqueTrees.jl](https:/
 
 | Algorithm | Description | Time Complexity | Space Complexity |
 |:-----------|:-------------|:----------------|:-----------------|
-| `BFS` | breadth-first search | O(m + n) | O(n) |
-| `MCS` | maximum cardinality search | O(m + n) | O(n) |
-| `LexBFS` | lexicographic breadth-first search | O(m + n) | O(m + n) |
-| `RCMMD` | reverse Cuthill-Mckee (minimum degree) | O(m + n) | O(m + n) |
-| `RCMGL` | reverse Cuthill-Mckee (George-Liu) | O(m + n) | O(m + n) |
-| `MCSM` | maximum cardinality search (minimal) | O(mn) | O(n) |
-| `LexM` | lexicographic breadth-first search (minimal) | O(mn) | O(n) |
 | `AMF` | approximate minimum fill | O(mn) | O(m + n) |
 | `MF` | minimum fill | O(mn²) | - |
 | `MMD` | multiple minimum degree | O(mn²) | O(m + n) |
@@ -39,15 +32,15 @@ Dict{Char, Int64} with 6 entries:
   'b' => 4
 
 julia> optcode = optimize_code(eincode, size_dict, optimizer)
-ba, ab -> a
-├─ bcf, fac -> ba
-│  ├─ e, bcef -> bcf
-│  │  ├─ e
-│  │  └─ bcef
-│  └─ df, acd -> fac
-│     ├─ df
-│     └─ acd
-└─ ab
+ab, ba -> a
+├─ ab
+└─ bcf, acf -> ba
+   ├─ bcef, e -> bcf
+   │  ├─ bcef
+   │  └─ e
+   └─ acd, df -> acf
+      ├─ acd
+      └─ df
 ```
 """
 Base.@kwdef struct Treewidth{EL <: EliminationAlgorithm} <: CodeOptimizer 

--- a/src/treewidth.jl
+++ b/src/treewidth.jl
@@ -223,6 +223,14 @@ function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:Abst
         end
     end
 
+    # append scalars to the root
+    for (v, ix) in enumerate(ixs)
+        if isempty(ix)
+            push!(code.args, NestedEinsum{L}(v))
+            push!(code.eins.ixs, ix)
+        end
+    end
+
     if binary
         code = _optimize_code(code, size_dict, GreedyMethod())
     end

--- a/src/treewidth.jl
+++ b/src/treewidth.jl
@@ -70,11 +70,11 @@ ExactTreewidth() = Treewidth()
 Optimizing the contraction order via solve the exact tree width of the line graph corresponding to the eincode and return a `NestedEinsum` object.
 Check the docstring of `treewidth_method` for detailed explaination of other input arguments.
 """
-function optimize_treewidth(optimizer::Treewidth{EL}, code::AbstractEinsum, size_dict::Dict) where {EL}
-    optimize_treewidth(optimizer, getixsv(code), getiyv(code), size_dict)
+function optimize_treewidth(optimizer::Treewidth{EL}, code::AbstractEinsum, size_dict::Dict; binary::Bool=true) where {EL}
+    optimize_treewidth(optimizer, getixsv(code), getiyv(code), size_dict; binary)
 end
 
-function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:AbstractVector}, iy::AbstractVector, size_dict::Dict{L,TI}) where {L, TI, EL}
+function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:AbstractVector}, iy::AbstractVector, size_dict::Dict{L,TI}; binary::Bool=true) where {L, TI, EL}
     le = Dict{L, Int}(); el = L[]
 
     marker = zeros(Int, max(length(size_dict), length(ixs) + 1))
@@ -223,5 +223,24 @@ function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:Abst
         end
     end
 
+    if binary
+        code = _optimize_code(code, size_dict, GreedyMethod())
+    end
+
     return code
+end
+
+# no longer used
+function il2lg(incidence_list::IncidenceList{VT, ET}, indicies::Vector{ET}) where {VT, ET}
+    line_graph = SimpleGraph(length(indicies))
+    
+    for (i, e) in enumerate(indicies)
+        for v in incidence_list.e2v[e]
+            for ej in incidence_list.v2e[v]
+                if e != ej add_edge!(line_graph, i, findfirst(==(ej), indicies)) end
+            end
+        end
+    end
+
+    return line_graph
 end

--- a/src/treewidth.jl
+++ b/src/treewidth.jl
@@ -109,7 +109,7 @@ function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:Abst
         push!(colptr, length(rowval) + 1)
     end
 
-    # add a "virtual" tensor with indices `head(path)`
+    # add a "virtual" tensor with indices `iy`
     v = length(colptr)
 
     for l in iy

--- a/src/treewidth.jl
+++ b/src/treewidth.jl
@@ -75,9 +75,15 @@ function optimize_treewidth(optimizer::Treewidth{EL}, code::AbstractEinsum, size
 end
 
 function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:AbstractVector}, iy::AbstractVector, size_dict::Dict{L,TI}; binary::Bool=true) where {L, TI, EL}
-    le = Dict{L, Int}(); el = L[]
-
     marker = zeros(Int, max(length(size_dict), length(ixs) + 1))
+
+    # construct incidence matrix `ve`
+    #           indices
+    #         [         ]
+    # tensors [    ve   ]
+    #         [         ]
+    # we only care about the sparsity pattern
+    le = Dict{L, Int}(); el = L[] # el ∘ le = id
     weights = Float64[]
     colptr = Int[1]
     rowval = Int[]
@@ -103,6 +109,7 @@ function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:Abst
         push!(colptr, length(rowval) + 1)
     end
 
+    # add a "virtual" tensor with indices `head(path)`
     v = length(colptr)
 
     for l in iy

--- a/src/treewidth.jl
+++ b/src/treewidth.jl
@@ -70,13 +70,87 @@ ExactTreewidth() = Treewidth()
 Optimizing the contraction order via solve the exact tree width of the line graph corresponding to the eincode and return a `NestedEinsum` object.
 Check the docstring of `treewidth_method` for detailed explaination of other input arguments.
 """
-function optimize_treewidth(optimizer::Treewidth{EL}, code::AbstractEinsum, size_dict::Dict; binary::Bool=true) where {EL}
+function optimize_treewidth(optimizer::Treewidth, code::AbstractEinsum, size_dict::Dict; binary::Bool=true)
     optimize_treewidth(optimizer, getixsv(code), getiyv(code), size_dict; binary)
 end
 
-function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:AbstractVector}, iy::AbstractVector, size_dict::Dict{L,TI}; binary::Bool=true) where {L, TI, EL}
-    marker = zeros(Int, max(length(size_dict), length(ixs) + 1))
+function optimize_treewidth(optimizer::Treewidth, ixs::AbstractVector{<:AbstractVector}, iy::AbstractVector, size_dict::Dict{L, Int}; binary::Bool=true) where {L}
+    marker = zeros(Int, max(length(ixs) + 1, length(size_dict)))
 
+    # construct incidence matrix `ve`
+    #           indices
+    #         [         ]
+    # tensors [    ve   ]
+    #         [         ]
+    # we only care about the sparsity pattern
+    weights, ev, ve, el = einexpr_to_matrix!(marker, ixs, iy, size_dict)
+
+    # compute a tree (forest) decomposition of `ve`
+    tree = matrix_to_tree!(marker, weights, ev, ve, el, optimizer.alg)
+
+    # transform tree decomposition in contraction tree
+    code = tree_to_einexpr!(marker, tree, ve, el, ixs, iy)
+
+    if binary
+        # binarize contraction tree
+        code = _optimize_code(code, size_dict, GreedyMethod())
+    end
+
+    return code
+end
+
+"""
+    einexpr_to_matrix!(marker, ixs, iy, size_dict)
+
+Construct the weighted incidence matrix correponding to an Einstein summation expression.
+Returns a quadruple (weights, ev, ve, el).
+
+Each Einstein summation expression has a set
+
+    E ⊆ L
+
+of indices, a set
+
+    V := {1, … |V|}
+
+of (inner) tensors, and an outer tensor
+
+    * := |V| + 1.
+
+Each tensor v ∈ V is incident to a sequence ixs[v] of indices, and the outer tensor is incident
+to the sequence iy.  Note that an index can appear multiple times
+in ixs[v], i.e.
+
+    ixs[v] = ('a', 'a', 'b').
+
+Each index l ∈ E has a positive dimension, given by size_dict[l].
+
+The function `einexpr_to_matrix` does two things. First of all, it enumerates the index set
+E, mapping each index to a distinct natural number.
+
+    el: {1, …, |E|} → E
+
+Next, it constructs a vector
+
+    weights: {1, …, |E|} → [0, ∞)
+
+satisfying
+
+    weights[e] := log2(size_dict[el[e]]),
+
+and a sparse matrix
+
+    ve: {1, …, |V| + 1} × {1, …, |E|} → {0, 1}
+
+satisfying
+
+    ve[v, e] := { 1 if el[e] is incident to v
+                { 0 otherwise
+
+We can think of the pair H := (weights, ve) as an edge-weighted hypergraph
+with incidence matrix ve.
+"""
+function einexpr_to_matrix!(marker::AbstractVector{Int}, ixs::AbstractVector{<:AbstractVector{L}}, iy::AbstractVector{L}, size_dict::AbstractDict{L}) where {L}
     # construct incidence matrix `ve`
     #           indices
     #         [         ]
@@ -89,8 +163,11 @@ function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:Abst
     rowval = Int[]
     nzval = Int[]    
 
+    # for all tensors v...
     for (v, ix) in enumerate(ixs)
+        # for each index l incident to v...
         for l in ix
+            # let e := le[l]
             if haskey(le, l)
                 e = le[l]
             else
@@ -99,8 +176,12 @@ function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:Abst
                 e = le[l] = length(el)
             end
 
+            # if l has not been seen before in ixs[v]...
             if marker[e] < v
+                # mark e as seen
                 marker[e] = v
+
+                # set ev[e, v] := 1
                 push!(rowval, e)
                 push!(nzval, 1)
             end           
@@ -109,10 +190,12 @@ function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:Abst
         push!(colptr, length(rowval) + 1)
     end
 
-    # add a "virtual" tensor with indices `iy`
+    # v is the outer tensor
     v = length(colptr)
 
+    # for each index l incident to v...
     for l in iy
+        # let e := le[l]
         if haskey(le, l)
             e = le[l]
         else
@@ -121,8 +204,12 @@ function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:Abst
             e = le[l] = length(el)
         end
 
+        # if l has not been seen before in iy...
         if marker[e] < v
+            # mark e as seen
             marker[e] = v
+
+            # set ev[e, v] = 1
             push!(rowval, e)
             push!(nzval, 1)
         end           
@@ -135,6 +222,18 @@ function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:Abst
 
     ev = SparseMatrixCSC{Int, Int}(m, n, colptr, rowval, nzval)
     ve = copy(transpose(ev))
+    return weights, ev, ve, el
+end
+
+"""
+    matrix_to_tree!(marker, weights, ev, ve, el, alg)
+
+Construct a tree decomposition of an edge-weighted hypergraph using
+the elimination algorithm `alg`. We ensure that the indices incident
+to the outer tensor are contained in the root bag of the tree decomposition.
+"""
+function matrix_to_tree!(marker::AbstractVector{Int}, weights::AbstractVector{Float64}, ev::SparseMatrixCSC{Int, Int}, ve::SparseMatrixCSC{Int, Int}, el::AbstractVector{L}, alg::EliminationAlgorithm) where {L}
+    n, m = size(ve); tag = n + 1
 
     # construct line graph `ee`
     #           indices
@@ -144,71 +243,107 @@ function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:Abst
     # we only care about the sparsity pattern
     ee = ve' * ve
 
-    # compute a tree (forest) decomposition of `ee`
-    perm, tree = cliquetree(weights, ee; alg=ConnectedComponents(optimizer.alg))
+    # compute a tree (forest) decomposition of ee
+    perm, tree = cliquetree(weights, ee; alg=ConnectedComponents(alg))
 
-    # find the bag containing `iy`, call it `root`
+    # find the bag containing iy, call it root
     root = length(tree)
 
+    # mark the indices in iy
     for e in view(rowvals(ev), nzrange(ev, n))
-        marker[e] = -1
+        marker[e] = tag
     end
 
+    # the first bag containing an index in iy
+    # must contain all of iy
     for (b, bag) in enumerate(tree)
         root < length(tree) && break
 
         for e in residual(bag)
             root < length(tree) && break
 
-            if marker[perm[e]] == -1
+            if marker[perm[e]] == tag
                 root = b
             end
         end
     end
 
-    # make `root` a root node of the tree decomposition
+    # make root a root node of the tree decomposition
     permute!(perm, cliquetree!(tree, root))
 
-    # permute incidence matrix `ve`
+    # permute incidence matrix `ve` and label vector `el`.
+    permute!(ve, axes(ve, 1), perm)
     permute!(el, perm)
-    permute!(ve, oneto(n), perm)
+
+    return tree
+end
+
+"""
+    tree_to_einexpr!(marker, tree, ve, el, ixs, iy)
+
+Transform a tree decomposition into a contraction tree.
+"""
+function tree_to_einexpr!(marker::AbstractVector{Int}, tree::CliqueTree{Int, Int}, ve::SparseMatrixCSC{Int, Int}, el::AbstractVector{L}, ixs::AbstractVector{<:AbstractVector{L}}, iy::AbstractVector{L}) where {L}
+    n, m = size(ve); tag = n + 2
 
     # dynamic programming
     stack = NestedEinsum{L}[]
 
+    # for each bag b...
     for (b, bag) in enumerate(tree)
+        # sep is the separator at b
         sep = separator(bag)
+
+        # res is the residual at b
         res = residual(bag)
+
+        # code is the Einstein summation expression at b
         code = NestedEinsum(NestedEinsum{L}[], EinCode(Vector{L}[], L[]))
 
         for e in sep
             push!(code.eins.iy, el[e])
         end
 
-        for e in res, v in view(rowvals(ve), nzrange(ve, e))
-            if marker[v] != -2
-                marker[v] = -2
+        # for each index e in the residual...
+        for e in res
+            # for each tensor v indicent to e...
+            for v in view(rowvals(ve), nzrange(ve, e))
+                # if has not been seen before...
+                if marker[v] < tag
+                    # mark v as seen
+                    marker[v] = tag
 
-                if v == n
-                    append!(code.eins.iy, iy)
-                else
-                    push!(code.args, NestedEinsum{L}(v))
-                    push!(code.eins.ixs, ixs[v])
+                    # if v is the outer tensor...
+                    if v == n
+                        # expose iy
+                        append!(code.eins.iy, iy)
+                    # if v is an inner tensor...
+                    else
+                        # make v a child of code
+                        push!(code.args, NestedEinsum{L}(v))
+                        push!(code.eins.ixs, ixs[v])
+                    end
                 end
             end
         end
 
+        # for each child bag of b...
         for _ in childindices(tree, b)
+            # the Einstein summation expression corresponding to
+            # the child bag is at the top of the stack
             child = pop!(stack)
+
+            # make this expression a child of code
             push!(code.args, child)
             push!(code.eins.ixs, child.eins.iy)
         end
 
+        # push code to the stack
         push!(stack, code)
     end
 
-    # we now have an expression for each root
-    # of the tree decomposition
+    # we now have an expression for each root of the tree decomposition.
+    # merge these together into a single Einstein expression code.
     if isone(length(stack))
         code = only(stack)
     else
@@ -222,16 +357,12 @@ function optimize_treewidth(optimizer::Treewidth{EL}, ixs::AbstractVector{<:Abst
         end
     end
 
-    # append scalars to the root
+    # append scalars to code
     for (v, ix) in enumerate(ixs)
         if isempty(ix)
             push!(code.args, NestedEinsum{L}(v))
             push!(code.eins.ixs, ix)
         end
-    end
-
-    if binary
-        code = _optimize_code(code, size_dict, GreedyMethod())
     end
 
     return code

--- a/test/treewidth.jl
+++ b/test/treewidth.jl
@@ -97,8 +97,9 @@ end
 end
 
 @testset "trace operation" begin
-    code = OMEinsumContractionOrders.EinCode([['a', 'b'], ['a', 'a', 'd'], ['b', 'c', 'e', 'f']], Char['z'])
-    size_dict = Dict([c=>2 for c in ['a', 'b', 'c', 'd', 'e', 'f']]..., 'z'=>2)
+    code = OMEinsumContractionOrders.EinCode([['a', 'b'], ['a', 'a', 'd'], ['b', 'c', 'e', 'f']], Char['f'])
+    size_dict = Dict([c=>2 for c in ['a', 'b', 'c', 'd', 'e', 'f']])
+    tensors = [rand([size_dict[j] for j in ixs]...) for ixs in getixsv(code)]
     optcode = optimize_code(code, size_dict, Treewidth(; alg=AMF()))
-    @test optcode == OMEinsumContractionOrders.NestedEinsum([OMEinsumContractionOrders.NestedEinsum([OMEinsumContractionOrders.NestedEinsum{Char}(2), OMEinsumContractionOrders.NestedEinsum{Char}(1)], OMEinsumContractionOrders.EinCode([['a', 'a', 'd'], ['a', 'b']], ['b'])), OMEinsumContractionOrders.NestedEinsum{Char}(3)], OMEinsumContractionOrders.EinCode([['b'], ['b', 'c', 'e', 'f']], ['z']))
+    @test decorate(code)(tensors...) ≈ decorate(optcode)(tensors...)
 end


### PR DESCRIPTION
Hi @GiggleLiu I hope you are well.

I just released an update to CliqueTrees.jl. You should notice that the `MF` and `ND` elimination algorithms are much, much faster, now. In fact, they are so fast that a great deal of the running time comes from setting up the problem in [treewidth.jl](https://github.com/TensorBFS/OMEinsumContractionOrders.jl/blob/master/src/treewidth.jl) file. The PR rewrites the file, speeding things up. It also fixes [this printing bug](https://github.com/TensorBFS/OMEinsumContractionOrders.jl/issues/94).

I made a couple decisions which I would like your advice on. At [this point](https://github.com/TensorBFS/OMEinsumContractionOrders.jl/blob/9fcdb6fe76c7f5ce3bd07728147a364d53402ef4/src/treewidth.jl#L233) in the `optimize_treewidth` function, the contraction schedule `code` is n-ary. As you can see, we "binarize" the tree by calling `code = _optimize_code(code, size_dict, GreedyMethod())`. This behavior is triggered by a keyword argument `binary`, which defaults to `true`.

Do contraction trees have to be binary? If so, is this the "right" way to binarize one? In practice, it seems to preserve the time and space complexity, but I suspect this is not a guarantee. Also, if n-ary trees are acceptable, then we might want to expose the `binary` keyword from the function `optimize_treewidth`.

Sincerely,
Richard Samuelson