### PR TITLE
Address JOSS issues 109-113 in paper references

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -83,7 +83,7 @@
    pages={410}
 }
 @article{Kalachev2021,
-      title={Recursive Multi-Tensor Contraction for XEB Verification of Quantum Circuits}, 
+      title={Multi-Tensor Contraction for XEB Verification of Quantum Circuits},
       author={Gleb Kalachev and Pavel Panteleev and Man-Hong Yung},
       journal={arXiv preprint arXiv:2108.05665},
       year={2021},
@@ -100,12 +100,13 @@
 }
 
 @book{Golub2013,
-  title={Matrix computations},
-  author={Golub, Gene H and Van Loan, Charles F},
-  volume={3},
+  title={Matrix Computations},
+  author={Golub, Gene H. and Van Loan, Charles F.},
+  edition={4},
   year={2013},
-  publisher={JHU press},
-  doi={10.2307/3621013}
+  publisher={Johns Hopkins University Press},
+  doi={10.56021/9781421407944},
+  isbn={9781421407944}
 }
 
 @article{Ng2001,
@@ -275,14 +276,17 @@
 }
 
 @article{Qing2024,
-  title = {Compressing Neural Network by Tensor Network with Exponentially Fewer Variational Parameters},
+  title = {Compressing Neural Networks Using Tensor Networks with Exponentially Fewer Variational Parameters},
   author = {Qing, Yong and Li, Ke and Zhou, Peng-Fei and Ran, Shi-Ju},
-  year = {2024},
+  year = {2025},
   month = may,
-  journal = {arXiv preprint arXiv:2305.06058},
+  journal = {Intelligent Computing},
+  volume = {4},
+  pages = {0123},
   eprint = {2305.06058},
-  primaryclass = {cs},
-  doi = {10.48550/arXiv.2305.06058},
+  primaryclass = {cs.LG},
+  doi = {10.34133/icomputing.0123},
+  url = {https://doi.org/10.34133/icomputing.0123},
   urldate = {2025-05-13},
   abstract = {Neural network (NN) designed for challenging machine learning tasks is in general a highly nonlinear mapping that contains massive variational parameters. High complexity of NN, if unbounded or unconstrained, might unpredictably cause severe issues including over-fitting, loss of generalization power, and unbearable cost of hardware. In this work, we propose a general compression scheme that significantly reduces the variational parameters of NN by encoding them to deep automatically-differentiable tensor network (ADTN) that contains exponentially-fewer free parameters. Superior compression performance of our scheme is demonstrated on several widely-recognized NN's (FC-2, LeNet-5, AlextNet, ZFNet and VGG-16) and datasets (MNIST, CIFAR-10 and CIFAR-100). For instance, we compress two linear layers in VGG-16 with approximately \$10{\textasciicircum}\{7\}\$ parameters to two ADTN's with just 424 parameters, where the testing accuracy on CIFAR-10 is improved from \$90.17 {\textbackslash}\%\$ to \$91.74{\textbackslash}\%\$. Our work suggests TN as an exceptionally efficient mathematical structure for representing the variational parameters of NN's, which exhibits superior compressibility over the commonly-used matrices and multi-way arrays.},
   archiveprefix = {arXiv},

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -23,34 +23,14 @@
   doi = {10.48550/arXiv.1209.5145},
   abstract = {Dynamic languages have become popular for scientific computing. They are generally considered highly productive, but lacking in performance. This paper presents Julia, a new dynamic language for technical computing, designed for performance from the beginning by adapting and extending modern programming language techniques. A design based on generic functions and a rich type system simultaneously enables an expressive programming model and successful type inference, leading to good performance for a wide range of programs. This makes it possible for much of the Julia library to be written in Julia itself, while also incorporating best-of-breed C and Fortran libraries.},
   urldate = {2018-11-27},
-  journal = {arXiv:1209.5145 [cs]},
+  journal = {arXiv preprint arXiv:1209.5145},
   author = {Bezanson, Jeff and Karpinski, Stefan and Shah, Viral B. and Edelman, Alan},
   month = sep,
   year = {2012},
-  note = {arXiv: 1209.5145},
+  eprint = {1209.5145},
+  archiveprefix = {arXiv},
   keywords = {Computer Science - Programming Languages, Computer Science - Computational Engineering, Finance, and Science, D.3.2},
   file = {arXiv.org Snapshot:/Users/apodusenko/Zotero/storage/V6P4IU54/1209.html:text/html;Bezanson et al. - 2012 - Julia A Fast Dynamic Language for Technical Compu.pdf:/Users/apodusenko/Zotero/storage/4Q9THC8V/Bezanson et al. - 2012 - Julia A Fast Dynamic Language for Technical Compu.pdf:application/pdf},
-}
-
-@article{Golub2016,
-  title = {Matrix {{Computation}}},
-  author = {Golub, Gene H.},
-  editor = {{Intergovernmental Panel on Climate Change}},
-  year = {2016},
-  volume = {25},
-  number = {3},
-  eprint = {1011.1669v3},
-  pages = {228--234},
-  publisher = {Cambridge University Press},
-  address = {Cambridge},
-  issn = {10623264},
-  doi = {10.4037/ajcc2016979},
-  abstract = {Predicting the binding mode of flexible polypeptides to proteins is an important task that falls outside the domain of applicability of most small molecule and protein-protein docking tools. Here, we test the small molecule flexible ligand docking program Glide on a set of 19 non-{$\alpha$}-helical peptides and systematically improve pose prediction accuracy by enhancing Glide sampling for flexible polypeptides. In addition, scoring of the poses was improved by post-processing with physics-based implicit solvent MM- GBSA calculations. Using the best RMSD among the top 10 scoring poses as a metric, the success rate (RMSD {$\leq$} 2.0 {\AA} for the interface backbone atoms) increased from 21\% with default Glide SP settings to 58\% with the enhanced peptide sampling and scoring protocol in the case of redocking to the native protein structure. This approaches the accuracy of the recently developed Rosetta FlexPepDock method (63\% success for these 19 peptides) while being over 100 times faster. Cross-docking was performed for a subset of cases where an unbound receptor structure was available, and in that case, 40\% of peptides were docked successfully. We analyze the results and find that the optimized polypeptide protocol is most accurate for extended peptides of limited size and number of formal charges, defining a domain of applicability for this approach.},
-  archiveprefix = {arXiv},
-  isbn = {9788578110796},
-  pmid = {25246403},
-  keywords = {Mobile,Named entity disambiguation,Natural language processing,News,Recommender system},
-  file = {/Users/liujinguo/Zotero/storage/5AZ5KKJF/Golub_2016_Matrix Computation.pdf}
 }
 
 @incollection{Alman2021,
@@ -68,9 +48,10 @@
   file = {/Users/liujinguo/Zotero/storage/4I9ZCACP/Alman and Williams - 2021 - A Refined Laser Method and Faster Matrix Multiplic.pdf}
 }
 
-@misc{Pan2021,
+@article{Pan2021,
       title={Simulating the Sycamore quantum supremacy circuits}, 
       author={Feng Pan and Pan Zhang},
+      journal={arXiv preprint arXiv:2103.03074},
       year={2021},
       eprint={2103.03074},
       archivePrefix={arXiv},
@@ -101,9 +82,10 @@
    month={Mar},
    pages={410}
 }
-@misc{Kalachev2021,
+@article{Kalachev2021,
       title={Recursive Multi-Tensor Contraction for XEB Verification of Quantum Circuits}, 
       author={Gleb Kalachev and Pavel Panteleev and Man-Hong Yung},
+      journal={arXiv preprint arXiv:2108.05665},
       year={2021},
       eprint={2108.05665},
       archivePrefix={arXiv},
@@ -135,10 +117,8 @@
 }
 
 @book{Bishop2006,
-  title={Pattern recognition and machine learning},
-  author={Bishop, Christopher M and Nasrabadi, Nasser M},
-  volume={4},
-  number={4},
+  title={Pattern Recognition and Machine Learning},
+  author={Bishop, Christopher M.},
   year={2006},
   publisher={Springer}
 }
@@ -294,15 +274,14 @@
   file = {/home/leo/snap/zotero-snap/common/Zotero/storage/IM6JTJMW/Liu et al. - 2021 - Tropical Tensor Network for Ground States of Spin .pdf}
 }
 
-@misc{Qing2024,
+@article{Qing2024,
   title = {Compressing Neural Network by Tensor Network with Exponentially Fewer Variational Parameters},
   author = {Qing, Yong and Li, Ke and Zhou, Peng-Fei and Ran, Shi-Ju},
   year = {2024},
   month = may,
-  number = {arXiv:2305.06058},
+  journal = {arXiv preprint arXiv:2305.06058},
   eprint = {2305.06058},
   primaryclass = {cs},
-  publisher = {arXiv},
   doi = {10.48550/arXiv.2305.06058},
   urldate = {2025-05-13},
   abstract = {Neural network (NN) designed for challenging machine learning tasks is in general a highly nonlinear mapping that contains massive variational parameters. High complexity of NN, if unbounded or unconstrained, might unpredictably cause severe issues including over-fitting, loss of generalization power, and unbearable cost of hardware. In this work, we propose a general compression scheme that significantly reduces the variational parameters of NN by encoding them to deep automatically-differentiable tensor network (ADTN) that contains exponentially-fewer free parameters. Superior compression performance of our scheme is demonstrated on several widely-recognized NN's (FC-2, LeNet-5, AlextNet, ZFNet and VGG-16) and datasets (MNIST, CIFAR-10 and CIFAR-100). For instance, we compress two linear layers in VGG-16 with approximately \$10{\textasciicircum}\{7\}\$ parameters to two ADTN's with just 424 parameters, where the testing accuracy on CIFAR-10 is improved from \$90.17 {\textbackslash}\%\$ to \$91.74{\textbackslash}\%\$. Our work suggests TN as an exceptionally efficient mathematical structure for representing the variational parameters of NN's, which exhibits superior compressibility over the commonly-used matrices and multi-way arrays.},
@@ -640,8 +619,10 @@
 @article{Magron2021,
   title={TSSOS: a Julia library to exploit sparsity for large-scale polynomial optimization},
   author={Magron, Victor and Wang, Jie},
-  journal={arXiv:2103.00915},
+  journal={arXiv preprint arXiv:2103.00915},
   year={2021},
+  eprint={2103.00915},
+  archiveprefix={arXiv},
   url={https://arxiv.org/abs/2103.00915}
 }
 
@@ -734,7 +715,7 @@
 }
 
 @article{Smith2018,
-	title = {opt\_einsum - A Python package for optimizing contraction order for einsum-like expressions},
+	title = {{{opt\_einsum}} - A Python package for optimizing contraction order for einsum-like expressions},
 	author = {Smith, Daniel G. A. and Gray, Johnnie},
 	journal = {Journal of Open Source Software},
 	volume = {3},
@@ -747,7 +728,7 @@
 }
 
 @article{Gray2018,
-	title = {quimb: A python package for quantum information and many-body calculations},
+	title = {{{quimb}}: A python package for quantum information and many-body calculations},
 	author = {Gray, Johnnie},
 	journal = {Journal of Open Source Software},
 	volume = {3},

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -111,7 +111,7 @@ The software exhibits strong community-readiness signals: comprehensive document
 # Features and Benchmarks
 
 A major feature of OMECO is contraction order optimization.
-OMECO provides several algorithms with complementary performance characteristics that can be simply called by the `optimize_code` function:
+OMECO provides several algorithms with complementary performance characteristics that can be simply called by the `optimize_code` function. \autoref{tbl:optimizers} summarizes the available optimizers and their roles:
 
 | Optimizer | Description |
 | :----------- | :------------- |
@@ -123,6 +123,8 @@ OMECO provides several algorithms with complementary performance characteristics
 | `SABipartite` | Simulated annealing bipartition method, pure Julia implementation |
 | `ExactTreewidth` | Exact algorithm with exponential runtime [@Bouchitte2001], based on [`TreeWidthSolver`](https://github.com/ArrogantGao/TreeWidthSolver.jl) |
 | `Treewidth` | Clique tree elimination methods from `CliqueTrees` package [@CliqueTrees2025] |
+
+: Summary of the contraction order optimizers available through `optimize_code`. {#tbl:optimizers}
 
 The algorithms `HyperND`, `Treewidth`, and `ExactTreewidth` are tree-width-based solvers that operate on graphs. They first convert tensor networks to their line graph representation [@Markov2008] and then find an optimized tree decomposition of the line graph using the `CliqueTrees` and `TreeWidthSolver` packages, as illustrated in \autoref{fig:structure}. Additionally, the `PathSA` optimizer optimizes path decomposition instead of tree decomposition. It is a variant of `TreeSA` by constraining contraction orders to path graphs, which is useful for applications requiring a linear contraction order.
 
@@ -178,4 +180,3 @@ The figure below illustrates these concepts with (a) a tensor network containing
 
 The tree decomposition in \autoref{fig:mainfig}(c) consists of 6 bags, each containing at most 3 indices, indicating that the treewidth of the tensor network is 2. The tensors $T_1$, $T_2$, $T_3$ and $T_4$ are contained in bags $B_1$, $B_5$, $B_6$ and $B_2$ respectively. Following the tree structure, we perform the contraction from the leaves. First, we contract bags $B_1$ and $B_2$ into $B_3$, yielding an intermediate tensor $I_{14} = T_1 * T_4$ (where "$*$" denotes tensor contraction) with indices $B$ and $E$. Next, we contract bags $B_5$ and $B_6$ into $B_4$, producing another intermediate tensor $I_{23} = T_2 * T_3$ also with indices $B$ and $E$. Finally, contracting $B_3$ and $B_4$ yields the desired scalar result.
  -->
-


### PR DESCRIPTION
## Summary
- Fix the manuscript bibliography and table-caption issues behind #109-#113.
- Verify and correct the affected reference metadata against JOSS, arXiv, and publisher sources.
- Add a caption and cross-reference for the optimizer table.

## Test Plan
- git diff --check -- paper/paper.bib paper/paper.md
- julia --project=. -e 'using Pkg; Pkg.test()'
- Attempted sh compile.sh twice; Docker Hub returned EOF while pulling openjournals/inara:latest

## Reference Audit
- Verified: bezanson2012julia, Pan2021, Kalachev2021, Qing2024, Magron2021, Bishop2006, Golub2013, Smith2018, Gray2018
- Judgment call: Qing2024 now cites the published Intelligent Computing article because the arXiv page links that journal version. If strict preprint-only style is preferred, this can be reverted.