### PR TITLE
Fix remaining bib entry issues from JOSS review

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -49,10 +49,15 @@
 }
 
 @article{Pan2021,
-      title={Simulating the Sycamore quantum supremacy circuits}, 
+      title={Simulating the Sycamore quantum supremacy circuits},
       author={Feng Pan and Pan Zhang},
-      journal={arXiv preprint arXiv:2103.03074},
-      year={2021},
+      journal={Physical Review Letters},
+      volume={128},
+      number={3},
+      pages={030501},
+      year={2022},
+      publisher={American Physical Society},
+      doi={10.1103/PhysRevLett.128.030501},
       eprint={2103.03074},
       archivePrefix={arXiv},
       primaryClass={quant-ph}
@@ -83,7 +88,7 @@
    pages={410}
 }
 @article{Kalachev2021,
-      title={Multi-Tensor Contraction for XEB Verification of Quantum Circuits},
+      title={Recursive Multi-Tensor Contraction for XEB Verification of Quantum Circuits},
       author={Gleb Kalachev and Pavel Panteleev and Man-Hong Yung},
       journal={arXiv preprint arXiv:2108.05665},
       year={2021},
@@ -621,13 +626,17 @@
 }
 
 @article{Magron2021,
-  title={TSSOS: a Julia library to exploit sparsity for large-scale polynomial optimization},
+  title={{TSSOS}: A Julia Library to Exploit Sparsity for Large-Scale Polynomial Optimization},
   author={Magron, Victor and Wang, Jie},
-  journal={arXiv preprint arXiv:2103.00915},
-  year={2021},
+  journal={ACM Transactions on Mathematical Software},
+  volume={49},
+  number={4},
+  pages={1--31},
+  year={2023},
+  publisher={ACM},
+  doi={10.1145/3618299},
   eprint={2103.00915},
-  archiveprefix={arXiv},
-  url={https://arxiv.org/abs/2103.00915}
+  archiveprefix={arXiv}
 }
 
 @misc{CliqueTrees2025,


### PR DESCRIPTION
## Summary
- Restore "Recursive" in Kalachev2021 title — was erroneously dropped in #115
- Update Pan2021 from arXiv preprint to published PRL version (Phys. Rev. Lett. 128, 030501, 2022)
- Update Magron2021 from arXiv preprint to published ACM TOMS version (vol. 49, no. 4, 2023)

## Issues Addressed
Follow-up fixes for #109–#113 (all now fully resolved):

| Issue | Status |
|-------|--------|
| #109 Golub2016 citation incorrect | Fixed in #115 ✓ |
| #110 Protect `quimb` from capitalization | Fixed in #115 ✓ |
| #111 Bishop reference authorship | Fixed in #115 ✓ |
| #112 Normalize references to preprints | **Completed here** — Pan2021 and Magron2021 now cite published journal versions |
| #113 Add caption to table | Fixed in #115 ✓ |

## Test Plan
- [x] `git diff --check -- paper/paper.bib` passes (no whitespace errors)
- [x] Verified titles, DOIs, and metadata against publisher pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)