### PR TITLE
Fix use of `\rm` and incorrect label syntax in paper

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -124,7 +124,7 @@ OMECO provides several algorithms with complementary performance characteristics
 | `ExactTreewidth` | Exact algorithm with exponential runtime [@Bouchitte2001], based on [`TreeWidthSolver`](https://github.com/ArrogantGao/TreeWidthSolver.jl) |
 | `Treewidth` | Clique tree elimination methods from `CliqueTrees` package [@CliqueTrees2025] |
 
-: Summary of the contraction order optimizers available through `optimize_code`. {#tbl:optimizers}
+: Summary of the contraction order optimizers available through `optimize_code`.\label{tbl:optimizers}
 
 The algorithms `HyperND`, `Treewidth`, and `ExactTreewidth` are tree-width-based solvers that operate on graphs. They first convert tensor networks to their line graph representation [@Markov2008] and then find an optimized tree decomposition of the line graph using the `CliqueTrees` and `TreeWidthSolver` packages, as illustrated in \autoref{fig:structure}. Additionally, the `PathSA` optimizer optimizes path decomposition instead of tree decomposition. It is a variant of `TreeSA` by constraining contraction orders to path graphs, which is useful for applications requiring a linear contraction order.
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -69,9 +69,9 @@ The tensor network framework has remarkable universality across diverse domains:
 
 A contraction order can be represented as a binary tree where leaves correspond to input tensors and internal nodes represent intermediate results. The optimization objective balances multiple complexity measures through the cost function:
 $$
-\mathcal{L} = w_\text{t} \cdot \text{tc} + w_\text{s} \cdot \max(0, \text{sc} - \text{sc}_{\rm target}) + w_\text{rw} \cdot \text{rwc},
+\mathcal{L} = w_\text{t} \cdot \text{tc} + w_\text{s} \cdot \max(0, \text{sc} - \text{sc}_{\textrm{target}}) + w_\text{rw} \cdot \text{rwc},
 $$
-where $w_\text{t}$, $w_\text{s}$, and $w_\text{rw}$ represent weights for time complexity (tc), space complexity (sc), and read-write complexity (rwc), respectively. In practice, memory access costs typically dominate computational costs, motivating $w_\text{rw} > w_\text{t}$. The space complexity penalty activates only when $\text{sc} > \text{sc}_{\rm target}$, allowing unconstrained optimization when memory fits within available device capacity.
+where $w_\text{t}$, $w_\text{s}$, and $w_\text{rw}$ represent weights for time complexity (tc), space complexity (sc), and read-write complexity (rwc), respectively. In practice, memory access costs typically dominate computational costs, motivating $w_\text{rw} > w_\text{t}$. The space complexity penalty activates only when $\text{sc} > \text{sc}_{\textrm{target}}$, allowing unconstrained optimization when memory fits within available device capacity.
 
 Finding the optimal contraction order—even when minimizing only time complexity—is NP-complete [@Markov2008]. However, the problem exhibits fixed-parameter tractability: for tensor networks with bounded tree-width, optimal contraction orders can be found—and the resulting contractions executed—in polynomial time. This connection to tree decomposition motivates several of OMECO's optimization strategies, which leverage graph-theoretic techniques to exploit this structure.
 


### PR DESCRIPTION
This PR fixes two things:

- The cross-reference to the table was incorrect. Use `\label{}` instead.
- `\rm` isn't a standard latex command. I guess that you meant to use `\textrm{}` instead (please check!)