### PR TITLE
Bump version to 1.2.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OMEinsumContractionOrders"
 uuid = "6f22d1fd-8eed-4bb7-9776-e7d684900715"
-version = "1.2.4"
+version = "1.2.5"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
Bumps the version to `1.2.5` so the `ExhaustiveSearch` optimizer added in #119 can be tagged and registered.

`ExhaustiveSearch` was merged after the `v1.2.4` tag was cut, so it is currently only available on `master` and cannot be resolved from the General registry. This patch bump lets a release be made that includes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)